### PR TITLE
[feat] 리프레시 토큰을 통한 재발급 구현

### DIFF
--- a/src/main/java/com/iglooclub/nungil/controller/OauthController.java
+++ b/src/main/java/com/iglooclub/nungil/controller/OauthController.java
@@ -2,9 +2,14 @@ package com.iglooclub.nungil.controller;
 
 import com.iglooclub.nungil.dto.LoginResponse;
 import com.iglooclub.nungil.dto.OauthLoginRequest;
+import com.iglooclub.nungil.exception.GeneralException;
+import com.iglooclub.nungil.exception.TokenErrorResult;
 import com.iglooclub.nungil.service.OauthService;
+import com.iglooclub.nungil.service.TokenService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,9 +22,23 @@ import javax.servlet.http.HttpServletResponse;
 public class OauthController {
     private final OauthService oauthService;
 
+    private final TokenService tokenService;
+
     @PostMapping("/api/auth/kakao")
     public ResponseEntity<LoginResponse> kakaoLogin(@RequestBody OauthLoginRequest loginRequest, HttpServletRequest request, HttpServletResponse response) {
         LoginResponse loginResponse = oauthService.kakaoLogin(loginRequest.getCode(), request, response);
         return ResponseEntity.ok(loginResponse);
+    }
+
+    @PostMapping("/api/auth/refresh")
+    public ResponseEntity<LoginResponse> createNewAccessToken(@CookieValue(value = "refresh_token", required = false) String refreshToken) {
+        if (refreshToken == null) {
+            throw new GeneralException(TokenErrorResult.REFRESH_TOKEN_NOT_FOUND);
+        }
+
+        String newAccessToken = tokenService.createNewAccessToken(refreshToken);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new LoginResponse(newAccessToken));
     }
 }

--- a/src/main/java/com/iglooclub/nungil/dto/LoginResponse.java
+++ b/src/main/java/com/iglooclub/nungil/dto/LoginResponse.java
@@ -7,5 +7,4 @@ import lombok.Getter;
 @AllArgsConstructor
 public class LoginResponse {
     private String accessToken;
-    private String refreshToken;
 }

--- a/src/main/java/com/iglooclub/nungil/exception/CustomException.java
+++ b/src/main/java/com/iglooclub/nungil/exception/CustomException.java
@@ -1,0 +1,8 @@
+package com.iglooclub.nungil.exception;
+
+/**
+ * 사용자 정의 예외 클래스는 반드시 해당 인터페이스를 구현해야 한다.
+ */
+public interface CustomException {
+    ErrorResult getErrorResult();
+}

--- a/src/main/java/com/iglooclub/nungil/exception/ErrorResult.java
+++ b/src/main/java/com/iglooclub/nungil/exception/ErrorResult.java
@@ -1,0 +1,12 @@
+package com.iglooclub.nungil.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorResult {
+
+    HttpStatus getHttpStatus();
+
+    String getMessage();
+
+    String name();
+}

--- a/src/main/java/com/iglooclub/nungil/exception/GeneralException.java
+++ b/src/main/java/com/iglooclub/nungil/exception/GeneralException.java
@@ -11,4 +11,9 @@ public class GeneralException extends RuntimeException implements CustomExceptio
         super(errorResult.getMessage());
         this.errorResult = errorResult;
     }
+
+    public GeneralException(ErrorResult errorResult, Throwable cause) {
+        super(errorResult.getMessage(), cause);
+        this.errorResult = errorResult;
+    }
 }

--- a/src/main/java/com/iglooclub/nungil/exception/GeneralException.java
+++ b/src/main/java/com/iglooclub/nungil/exception/GeneralException.java
@@ -1,11 +1,14 @@
 package com.iglooclub.nungil.exception;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
 public class GeneralException extends RuntimeException implements CustomException {
 
     private final ErrorResult errorResult;
+
+    public GeneralException(ErrorResult errorResult) {
+        super(errorResult.getMessage());
+        this.errorResult = errorResult;
+    }
 }

--- a/src/main/java/com/iglooclub/nungil/exception/GeneralException.java
+++ b/src/main/java/com/iglooclub/nungil/exception/GeneralException.java
@@ -5,7 +5,7 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public class MemberException extends RuntimeException implements CustomException {
+public class GeneralException extends RuntimeException implements CustomException {
 
     private final ErrorResult errorResult;
 }

--- a/src/main/java/com/iglooclub/nungil/exception/GlobalErrorResult.java
+++ b/src/main/java/com/iglooclub/nungil/exception/GlobalErrorResult.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum GlobalErrorResult implements ErrorResult {
 
-    UNKNOWN_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "Unknown Exception")
+    UNKNOWN_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "Unknown Exception"),
+    JSON_PROCESSING_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "Problem occurred when processing json"),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/iglooclub/nungil/exception/GlobalErrorResult.java
+++ b/src/main/java/com/iglooclub/nungil/exception/GlobalErrorResult.java
@@ -1,0 +1,16 @@
+package com.iglooclub.nungil.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum GlobalErrorResult implements ErrorResult {
+
+    UNKNOWN_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "Unknown Exception")
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/iglooclub/nungil/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/iglooclub/nungil/exception/GlobalExceptionHandler.java
@@ -1,0 +1,76 @@
+package com.iglooclub.nungil.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    /**
+     * MethodArgumentNotValidException를 통해 발생한 필드 에러(@Valid)를 처리하는 메서드이다.
+     *
+     * @param ex      the exception
+     * @param headers the headers to be written to the response
+     * @param status  the selected response status
+     * @param request the current request
+     * @return 에러가 발생한 필드 목록과 HTTP Bad Request 반환
+     */
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex,
+                                                                  HttpHeaders headers,
+                                                                  HttpStatus status,
+                                                                  WebRequest request) {
+
+        final List<String> errorList = ex.getBindingResult()
+                .getAllErrors()
+                .stream()
+                .map(DefaultMessageSourceResolvable::getDefaultMessage)
+                .collect(Collectors.toList());
+
+        log.warn("Invalid DTO Parameter errors : {}", errorList);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(HttpStatus.BAD_REQUEST.toString(), errorList.toString()));
+    }
+
+    @ExceptionHandler({
+            MemberException.class
+    })
+    public ResponseEntity<ErrorResponse> handleRestApiException(final CustomException exception) {
+        ErrorResult errorResult = exception.getErrorResult();
+
+        log.warn(errorResult.name() + " Exception occurred: ", exception);
+        return this.makeErrorResponseEntity(errorResult);
+    }
+
+    @ExceptionHandler({Exception.class})
+    public ResponseEntity<ErrorResponse> handleException(final Exception exception) {
+        log.warn("Exception occur: ", exception);
+        return this.makeErrorResponseEntity(GlobalErrorResult.UNKNOWN_EXCEPTION);
+    }
+
+    private ResponseEntity<ErrorResponse> makeErrorResponseEntity(final ErrorResult errorResult) {
+        return ResponseEntity.status(errorResult.getHttpStatus())
+                .body(new ErrorResponse(errorResult.name(), errorResult.getMessage()));
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    static class ErrorResponse {
+        private final String code;
+        private final String message;
+    }
+}

--- a/src/main/java/com/iglooclub/nungil/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/iglooclub/nungil/exception/GlobalExceptionHandler.java
@@ -47,7 +47,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     }
 
     @ExceptionHandler({
-            MemberException.class
+            GeneralException.class
     })
     public ResponseEntity<ErrorResponse> handleRestApiException(final CustomException exception) {
         ErrorResult errorResult = exception.getErrorResult();

--- a/src/main/java/com/iglooclub/nungil/exception/MemberErrorResult.java
+++ b/src/main/java/com/iglooclub/nungil/exception/MemberErrorResult.java
@@ -1,0 +1,18 @@
+package com.iglooclub.nungil.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberErrorResult implements ErrorResult {
+
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "Failed to find the refresh token in cookie"),
+    ANONYMOUS_USER(HttpStatus.UNAUTHORIZED, "Anonymous user"),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "Failed to find the User"),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/iglooclub/nungil/exception/MemberException.java
+++ b/src/main/java/com/iglooclub/nungil/exception/MemberException.java
@@ -1,0 +1,11 @@
+package com.iglooclub.nungil.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class MemberException extends RuntimeException implements CustomException {
+
+    private final ErrorResult errorResult;
+}

--- a/src/main/java/com/iglooclub/nungil/exception/TokenErrorResult.java
+++ b/src/main/java/com/iglooclub/nungil/exception/TokenErrorResult.java
@@ -6,10 +6,10 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
-public enum MemberErrorResult implements ErrorResult {
+public enum TokenErrorResult implements ErrorResult {
 
-    ANONYMOUS_USER(HttpStatus.UNAUTHORIZED, "Anonymous user"),
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "Failed to find the User"),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "Failed to find the refresh token in cookie"),
+    UNEXPECTED_TOKEN(HttpStatus.BAD_REQUEST, "Given token is not valid"),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/iglooclub/nungil/service/MemberService.java
+++ b/src/main/java/com/iglooclub/nungil/service/MemberService.java
@@ -1,0 +1,22 @@
+package com.iglooclub.nungil.service;
+
+import com.iglooclub.nungil.domain.Member;
+import com.iglooclub.nungil.exception.GeneralException;
+import com.iglooclub.nungil.exception.MemberErrorResult;
+import com.iglooclub.nungil.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+@Transactional(readOnly = true)
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public Member findById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new GeneralException(MemberErrorResult.USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/iglooclub/nungil/service/OauthService.java
+++ b/src/main/java/com/iglooclub/nungil/service/OauthService.java
@@ -9,6 +9,8 @@ import com.iglooclub.nungil.domain.OauthInfo;
 import com.iglooclub.nungil.domain.RefreshToken;
 import com.iglooclub.nungil.domain.enums.OauthProvider;
 import com.iglooclub.nungil.dto.LoginResponse;
+import com.iglooclub.nungil.exception.GeneralException;
+import com.iglooclub.nungil.exception.GlobalErrorResult;
 import com.iglooclub.nungil.repository.MemberRepository;
 import com.iglooclub.nungil.repository.RefreshTokenRepository;
 import com.iglooclub.nungil.util.CookieUtil;
@@ -138,7 +140,7 @@ public class OauthService {
         try {
             jsonNode = objectMapper.readTree(responseBody);
         } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
+            throw new GeneralException(GlobalErrorResult.JSON_PROCESSING_EXCEPTION, e);
         }
         return jsonNode.get("access_token").asText();
     }
@@ -170,7 +172,7 @@ public class OauthService {
         try {
             return objectMapper.readTree(responseBody);
         } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
+            throw new GeneralException(GlobalErrorResult.JSON_PROCESSING_EXCEPTION, e);
         }
     }
 

--- a/src/main/java/com/iglooclub/nungil/service/RefreshTokenService.java
+++ b/src/main/java/com/iglooclub/nungil/service/RefreshTokenService.java
@@ -1,0 +1,19 @@
+package com.iglooclub.nungil.service;
+
+import com.iglooclub.nungil.domain.RefreshToken;
+import com.iglooclub.nungil.exception.GeneralException;
+import com.iglooclub.nungil.exception.TokenErrorResult;
+import com.iglooclub.nungil.repository.RefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class RefreshTokenService {
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public RefreshToken findByRefreshToken(String refreshToken) {
+        return refreshTokenRepository.findByRefreshToken(refreshToken)
+                .orElseThrow(() -> new GeneralException(TokenErrorResult.UNEXPECTED_TOKEN));
+    }
+}

--- a/src/main/java/com/iglooclub/nungil/service/TokenService.java
+++ b/src/main/java/com/iglooclub/nungil/service/TokenService.java
@@ -1,0 +1,30 @@
+package com.iglooclub.nungil.service;
+
+import com.iglooclub.nungil.config.jwt.TokenProvider;
+import com.iglooclub.nungil.domain.Member;
+import com.iglooclub.nungil.exception.GeneralException;
+import com.iglooclub.nungil.exception.TokenErrorResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@RequiredArgsConstructor
+@Service
+public class TokenService {
+    private final TokenProvider tokenProvider;
+    private final RefreshTokenService refreshTokenService;
+    private final MemberService memberService;
+
+    public String createNewAccessToken(String refreshToken) {
+        // 토큰 유효성 검사에 실패하면 예외 발생
+        if (!tokenProvider.validateToken(refreshToken)) {
+            throw new GeneralException(TokenErrorResult.UNEXPECTED_TOKEN);
+        }
+
+        Long memberId = refreshTokenService.findByRefreshToken(refreshToken).getMemberId();
+        Member member = memberService.findById(memberId);
+
+        return tokenProvider.generateToken(member, Duration.ofHours(2));
+    }
+}

--- a/src/main/java/com/iglooclub/nungil/util/CookieUtil.java
+++ b/src/main/java/com/iglooclub/nungil/util/CookieUtil.java
@@ -1,0 +1,36 @@
+package com.iglooclub.nungil.util;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class CookieUtil {
+
+    /**
+     * 요청값(이름, 값, 만료기간)을 바탕으로 HttpOnly 쿠키를 추가하는 메서드이다.
+     */
+    public static void addHttpOnlyCookie(HttpServletResponse response, String name, String value, int maxAge) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setPath("/");
+        cookie.setMaxAge(maxAge);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        response.addCookie(cookie);
+    }
+
+    public static void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            return;
+        }
+
+        for (Cookie cookie : cookies) {
+            if (name.equals(cookie.getName())) {
+                cookie.setValue("");
+                cookie.setPath("/");
+                cookie.setMaxAge(0);
+                response.addCookie(cookie);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 🔥 Related Issues

- close #5 

## 💜 작업 내용

- [x] 리프레시 토큰을 HttpOnly 쿠키에 저장하도록 변경
- [x] 리프레시 토큰을 통한 액세스 토큰 재발급 구현
- [x] 예외 처리를 위한 클래스 초기화

## ✅ PR Point

### HttpOnly 쿠키에 리프레시 토큰 저장

- 쿠키에 토큰을 저장하기 위해 CookieUtil.java 클래스를 생성하고, 아래 메서드를 작성했습니다.

```java
public static void addHttpOnlyCookie(HttpServletResponse response, String name, String value, int maxAge) {
    Cookie cookie = new Cookie(name, value);
    cookie.setPath("/");
    cookie.setMaxAge(maxAge);
    cookie.setHttpOnly(true);
    cookie.setSecure(true);
    response.addCookie(cookie);
}
```

- 또한 기존의 로그인 이후 응답 DTO인 LoginResponse.java 클래스에서 refreshToken을 제외시켰습니다. 

- 이를 통해 Body에 리프레시 토큰을 포함시키는 방식보다 보안이 더 안전할 것으로 기대됩니다.

### 액세스 토큰 재발급 구현

- 쿠키에서 리프레시 토큰을 조회하고, 해당 토큰이 유효한 경우 새 액세스 토큰을 발급하도록 구현했습니다.

```java
@PostMapping("/api/auth/refresh")
public ResponseEntity<LoginResponse> createNewAccessToken(@CookieValue(value = "refresh_token", required = false) String refreshToken) {
    if (refreshToken == null) {
        throw new GeneralException(TokenErrorResult.REFRESH_TOKEN_NOT_FOUND);
    }

    String newAccessToken = tokenService.createNewAccessToken(refreshToken);

    return ResponseEntity.status(HttpStatus.CREATED)
            .body(new LoginResponse(newAccessToken));
}
```

### 예외 처리를 위한 클래스

- 에러 유형을 정의하는 ErrorResult 클래스와, 에러를 전역적으로 처리하는 GlobalExceptionHandler 클래스를 구현했습니다.

- 이전에 하던 방식과 달리 도메인 별로 예외 클래스를 만들지 않고, 일반적인 예외 상황이라면 GeneralException 클래스를 던지도록 하였습니다.

```java
@Getter
public class GeneralException extends RuntimeException implements CustomException {

    private final ErrorResult errorResult;

    public GeneralException(ErrorResult errorResult) {
        super(errorResult.getMessage());
        this.errorResult = errorResult;
    }

    public GeneralException(ErrorResult errorResult, Throwable cause) {
        super(errorResult.getMessage(), cause);
        this.errorResult = errorResult;
    }
}
```

## ☀ 스크린샷 / GIF / 화면 녹화

+ 카카오 로그인 결과, 쿠키에 리프레시 토큰 저장

![image](https://github.com/Igloo-Club/Igloo-Club-BE/assets/50361496/f18de6e3-357b-4fcc-b429-e79f3590ce43)

