### PR TITLE
[feat] 회원 관리 기능 구현

### DIFF
--- a/src/main/java/com/iglooclub/nungil/controller/MemberController.java
+++ b/src/main/java/com/iglooclub/nungil/controller/MemberController.java
@@ -1,0 +1,26 @@
+package com.iglooclub.nungil.controller;
+
+import com.iglooclub.nungil.domain.Member;
+import com.iglooclub.nungil.dto.ProfileCreateRequest;
+import com.iglooclub.nungil.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.security.Principal;
+
+@RestController
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping("/api/member")
+    public ResponseEntity<?> createProfile(@RequestBody ProfileCreateRequest request, Principal principal) {
+        Member member = memberService.findById(Long.parseLong(principal.getName()));
+        memberService.createProfile(member, request);
+        return ResponseEntity.ok(null);
+    }
+}

--- a/src/main/java/com/iglooclub/nungil/controller/MemberController.java
+++ b/src/main/java/com/iglooclub/nungil/controller/MemberController.java
@@ -3,13 +3,11 @@ package com.iglooclub.nungil.controller;
 import com.iglooclub.nungil.domain.Member;
 import com.iglooclub.nungil.dto.MemberDetailResponse;
 import com.iglooclub.nungil.dto.ProfileCreateRequest;
+import com.iglooclub.nungil.dto.ProfileUpdateRequest;
 import com.iglooclub.nungil.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
 
@@ -31,6 +29,13 @@ public class MemberController {
         Member member = getMember(principal);
         MemberDetailResponse memberDetail = memberService.getMemberDetail(member);
         return ResponseEntity.ok(memberDetail);
+    }
+
+    @PatchMapping("/api/member")
+    public ResponseEntity<?> updateProfile(@RequestBody ProfileUpdateRequest request, Principal principal) {
+        Member member = getMember(principal);
+        memberService.updateProfile(member, request);
+        return ResponseEntity.ok(null);
     }
 
     private Member getMember(Principal principal) {

--- a/src/main/java/com/iglooclub/nungil/controller/MemberController.java
+++ b/src/main/java/com/iglooclub/nungil/controller/MemberController.java
@@ -1,10 +1,12 @@
 package com.iglooclub.nungil.controller;
 
 import com.iglooclub.nungil.domain.Member;
+import com.iglooclub.nungil.dto.MemberDetailResponse;
 import com.iglooclub.nungil.dto.ProfileCreateRequest;
 import com.iglooclub.nungil.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,8 +21,19 @@ public class MemberController {
 
     @PostMapping("/api/member")
     public ResponseEntity<?> createProfile(@RequestBody ProfileCreateRequest request, Principal principal) {
-        Member member = memberService.findById(Long.parseLong(principal.getName()));
+        Member member = getMember(principal);
         memberService.createProfile(member, request);
         return ResponseEntity.ok(null);
+    }
+
+    @GetMapping("/api/member")
+    public ResponseEntity<MemberDetailResponse> getMemberDetail(Principal principal) {
+        Member member = getMember(principal);
+        MemberDetailResponse memberDetail = memberService.getMemberDetail(member);
+        return ResponseEntity.ok(memberDetail);
+    }
+
+    private Member getMember(Principal principal) {
+        return memberService.findById(Long.parseLong(principal.getName()));
     }
 }

--- a/src/main/java/com/iglooclub/nungil/domain/Contact.java
+++ b/src/main/java/com/iglooclub/nungil/domain/Contact.java
@@ -22,4 +22,11 @@ public class Contact {
 
     @Nullable
     private String instagram;
+
+    // == 비즈니스 로직 == //
+
+    public void update(String kakao, String instagram) {
+        this.kakao = kakao;
+        this.instagram = instagram;
+    }
 }

--- a/src/main/java/com/iglooclub/nungil/domain/FaceDepictionAllocation.java
+++ b/src/main/java/com/iglooclub/nungil/domain/FaceDepictionAllocation.java
@@ -1,0 +1,28 @@
+package com.iglooclub.nungil.domain;
+
+import com.iglooclub.nungil.domain.enums.FaceDepiction;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class FaceDepictionAllocation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private FaceDepiction faceDepiction;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+}

--- a/src/main/java/com/iglooclub/nungil/domain/HobbyAllocation.java
+++ b/src/main/java/com/iglooclub/nungil/domain/HobbyAllocation.java
@@ -1,5 +1,6 @@
 package com.iglooclub.nungil.domain;
 
+import com.iglooclub.nungil.domain.enums.Hobby;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,11 +13,12 @@ import javax.persistence.*;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class Hobby {
+public class HobbyAllocation {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String name;
+    @Enumerated(EnumType.STRING)
+    private Hobby hobby;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")

--- a/src/main/java/com/iglooclub/nungil/domain/Member.java
+++ b/src/main/java/com/iglooclub/nungil/domain/Member.java
@@ -88,8 +88,9 @@ public class Member {
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<HobbyAllocation> hobbyAllocationList = new ArrayList<>();
 
+    @Builder.Default
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-    private Contact contact;
+    private Contact contact = Contact.builder().build();
 
     @Builder.Default
     @OneToMany(mappedBy = "member")
@@ -133,15 +134,11 @@ public class Member {
      * @param request 프로필 등록 요청 DTO
      */
     public void createProfile(ProfileCreateRequest request) {
-        Contact newContact = Contact.builder()
-                .kakao(request.getContactKakao())
-                .instagram(request.getContactInstagram())
-                .build();
 
         this.nickname = request.getNickname();
         this.sex = request.getSex();
         this.birthdate = request.getBirthdate();
-        this.contact = newContact;
+        this.contact.update(request.getContactKakao(), request.getContactInstagram());
         this.animalFace = request.getAnimalFace();
         this.job = request.getJob();
         this.height = request.getHeight();

--- a/src/main/java/com/iglooclub/nungil/domain/Member.java
+++ b/src/main/java/com/iglooclub/nungil/domain/Member.java
@@ -80,8 +80,8 @@ public class Member {
     private Integer noshowCount = 0;
 
     @Builder.Default
-    @OneToMany(mappedBy = "member")
-    private List<Hobby> hobbyList = new ArrayList<>();
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<HobbyAllocation> hobbyList = new ArrayList<>();
 
     @OneToOne(fetch = FetchType.LAZY)
     private Contact contact;

--- a/src/main/java/com/iglooclub/nungil/domain/Member.java
+++ b/src/main/java/com/iglooclub/nungil/domain/Member.java
@@ -36,7 +36,8 @@ public class Member {
     @JoinColumn(name = "company_id")
     private Company company;
 
-    private Boolean disableCompany;
+    @Builder.Default
+    private Boolean disableCompany = true;
 
     @Enumerated(value = EnumType.STRING)
     private AnimalFace animalFace;
@@ -106,6 +107,7 @@ public class Member {
 
     public Member(){
         this.point = 0;
+        this.disableCompany = true;
         this.availableTimeList = new ArrayList<>();
         this.noshowCount = 0;
         this.hobbyList = new ArrayList<>();

--- a/src/main/java/com/iglooclub/nungil/domain/Member.java
+++ b/src/main/java/com/iglooclub/nungil/domain/Member.java
@@ -2,6 +2,7 @@ package com.iglooclub.nungil.domain;
 
 import com.iglooclub.nungil.domain.enums.*;
 import com.iglooclub.nungil.dto.ProfileCreateRequest;
+import com.iglooclub.nungil.dto.ProfileUpdateRequest;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -63,11 +64,11 @@ public class Member {
     private MarriageState marriageState;
 
     @Builder.Default
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<FaceDepictionAllocation> faceDepictionAllocationList = new ArrayList<>();
 
     @Builder.Default
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<PersonalityDepictionAllocation> personalityDepictionAllocationList = new ArrayList<>();
 
     @Column(length = 400)
@@ -77,17 +78,17 @@ public class Member {
     private Integer point = 0;
 
     @Builder.Default
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<AvailableTimeAllocation> availableTimeAllocationList = new ArrayList<>();
 
     @Builder.Default
     private Integer noshowCount = 0;
 
     @Builder.Default
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<HobbyAllocation> hobbyAllocationList = new ArrayList<>();
 
-    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private Contact contact;
 
     @Builder.Default
@@ -102,7 +103,7 @@ public class Member {
     @Builder.Default
     private List<LocationAllocation> locationList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     @Builder.Default
     private List<MarkerAllocation> markerAllocationList = new ArrayList<>();
 
@@ -152,6 +153,38 @@ public class Member {
         request.getAvailableTimeList().forEach(this::addAvailableTime);
         request.getHobbyList().forEach(this::addHobby);
 
+    }
+
+    public void updateProfile(ProfileUpdateRequest request,
+                              List<FaceDepictionAllocation> newFaceDepictionAllocationList,
+                              List<PersonalityDepictionAllocation> newPersonalityDepictionAllocationList,
+                              List<MarkerAllocation> newMarkerAllocationList,
+                              List<AvailableTimeAllocation> newAvailableTimeAllocationList,
+                              List<HobbyAllocation> newHobbyAllocationList) {
+
+        this.nickname = request.getNickname();
+        this.sex = request.getSex();
+        this.birthdate = request.getBirthdate();
+        this.contact.update(request.getContactKakao(), request.getContactInstagram());
+        this.animalFace = request.getAnimalFace();
+        this.job = request.getJob();
+        this.height = request.getHeight();
+        this.mbti = request.getMbti();
+        this.marriageState = request.getMarriageState();
+        this.religion = request.getReligion();
+        this.alcohol = request.getAlcohol();
+        this.smoke = request.getSmoke();
+        this.description = request.getDescription();
+
+        this.faceDepictionAllocationList = newFaceDepictionAllocationList;
+
+        this.personalityDepictionAllocationList = newPersonalityDepictionAllocationList;
+
+        this.markerAllocationList = newMarkerAllocationList;
+
+        this.availableTimeAllocationList = newAvailableTimeAllocationList;
+
+        this.hobbyAllocationList = newHobbyAllocationList;
     }
 
     // == 조회 로직 == //

--- a/src/main/java/com/iglooclub/nungil/domain/Member.java
+++ b/src/main/java/com/iglooclub/nungil/domain/Member.java
@@ -156,11 +156,11 @@ public class Member {
     }
 
     public void updateProfile(ProfileUpdateRequest request,
-                              List<FaceDepictionAllocation> newFaceDepictionAllocationList,
-                              List<PersonalityDepictionAllocation> newPersonalityDepictionAllocationList,
-                              List<MarkerAllocation> newMarkerAllocationList,
-                              List<AvailableTimeAllocation> newAvailableTimeAllocationList,
-                              List<HobbyAllocation> newHobbyAllocationList) {
+                              List<FaceDepictionAllocation> nonExistingFaceDepictions,
+                              List<PersonalityDepictionAllocation> nonExistingPersonalityDepictions,
+                              List<MarkerAllocation> nonExistingMarkers,
+                              List<AvailableTimeAllocation> nonExistingAvailableTimes,
+                              List<HobbyAllocation> nonExistingHobbies) {
 
         this.nickname = request.getNickname();
         this.sex = request.getSex();
@@ -176,15 +176,15 @@ public class Member {
         this.smoke = request.getSmoke();
         this.description = request.getDescription();
 
-        this.faceDepictionAllocationList = newFaceDepictionAllocationList;
+        this.faceDepictionAllocationList = nonExistingFaceDepictions;
 
-        this.personalityDepictionAllocationList = newPersonalityDepictionAllocationList;
+        this.personalityDepictionAllocationList = nonExistingPersonalityDepictions;
 
-        this.markerAllocationList = newMarkerAllocationList;
+        this.markerAllocationList = nonExistingMarkers;
 
-        this.availableTimeAllocationList = newAvailableTimeAllocationList;
+        this.availableTimeAllocationList = nonExistingAvailableTimes;
 
-        this.hobbyAllocationList = newHobbyAllocationList;
+        this.hobbyAllocationList = nonExistingHobbies;
     }
 
     // == 조회 로직 == //

--- a/src/main/java/com/iglooclub/nungil/domain/Member.java
+++ b/src/main/java/com/iglooclub/nungil/domain/Member.java
@@ -1,13 +1,13 @@
 package com.iglooclub.nungil.domain;
 
 import com.iglooclub.nungil.domain.enums.*;
+import com.iglooclub.nungil.dto.ProfileCreateRequest;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -30,7 +30,7 @@ public class Member {
     @Enumerated(value = EnumType.STRING)
     private Sex sex;
 
-    private LocalDateTime birthdate;
+    private LocalDate birthdate;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "company_id")
@@ -61,19 +61,22 @@ public class Member {
     @Enumerated(value = EnumType.STRING)
     private MarriageState marriageState;
 
-    @Enumerated(value = EnumType.STRING)
-    private FaceDepiction faceDepiction;
+    @Builder.Default
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<FaceDepictionAllocation> faceDepictionList = new ArrayList<>();
 
-    @Enumerated(value = EnumType.STRING)
-    private PersonalityDepiction personalityDepiction;
+    @Builder.Default
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PersonalityDepictionAllocation> personalityDepictionList = new ArrayList<>();
 
+    @Column(length = 400)
     private String description;
 
     @Builder.Default
     private Integer point = 0;
 
     @Builder.Default
-    @OneToMany(mappedBy = "member")
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<AvailableTimeAllocation> availableTimeList = new ArrayList<>();
 
     @Builder.Default
@@ -83,7 +86,7 @@ public class Member {
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<HobbyAllocation> hobbyList = new ArrayList<>();
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private Contact contact;
 
     @Builder.Default
@@ -95,10 +98,12 @@ public class Member {
     private List<Acquaintance> acquaintanceList = new ArrayList<>();
 
     @OneToMany(mappedBy = "member")
-    private List<LocationAllocation> locationList;
+    @Builder.Default
+    private List<LocationAllocation> locationList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "member")
-    private List<MarkerAllocation> markerList;
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<MarkerAllocation> markerList = new ArrayList<>();
 
     public Member update(String oauthAccess) {
         this.oauthAccess = oauthAccess;
@@ -113,5 +118,76 @@ public class Member {
         this.hobbyList = new ArrayList<>();
         this.nungilList = new ArrayList<>();
         this.acquaintanceList = new ArrayList<>();
+        this.faceDepictionList = new ArrayList<>();
+        this.personalityDepictionList = new ArrayList<>();
+        this.markerList = new ArrayList<>();
+        this.locationList = new ArrayList<>();
+    }
+
+    public void createProfile(ProfileCreateRequest request) {
+        Contact newContact = Contact.builder()
+                .kakao(request.getContactKakao())
+                .instagram(request.getContactInstagram())
+                .build();
+
+        this.nickname = request.getNickname();
+        this.sex = request.getSex();
+        this.birthdate = request.getBirthdate();
+        this.contact = newContact;
+        this.animalFace = request.getAnimalFace();
+        this.job = request.getJob();
+        this.height = request.getHeight();
+        this.mbti = request.getMbti();
+        this.marriageState = request.getMarriageState();
+        this.religion = request.getReligion();
+        this.alcohol = request.getAlcohol();
+        this.smoke = request.getSmoke();
+        request.getFaceDepictionList().forEach(this::addFaceDepiction);
+        request.getPersonalityDepictionList().forEach(this::addPersonalityDepiction);
+        this.description = request.getDescription();
+        request.getMarkerList().forEach(this::addMarker);
+        request.getAvailableTimeList().forEach(this::addAvailableTime);
+        request.getHobbyList().forEach(this::addHobby);
+
+    }
+
+    public void addFaceDepiction(FaceDepiction faceDepiction) {
+        FaceDepictionAllocation faceDepictionAllocation = FaceDepictionAllocation.builder()
+                .faceDepiction(faceDepiction)
+                .member(this)
+                .build();
+        this.faceDepictionList.add(faceDepictionAllocation);
+    }
+
+    public void addPersonalityDepiction(PersonalityDepiction personalityDepiction) {
+        PersonalityDepictionAllocation personalityDepictionAllocation = PersonalityDepictionAllocation.builder()
+                .personalityDepiction(personalityDepiction)
+                .member(this)
+                .build();
+        this.personalityDepictionList.add(personalityDepictionAllocation);
+    }
+
+    public void addMarker(Marker marker) {
+        MarkerAllocation markerAllocation = MarkerAllocation.builder()
+                .marker(marker)
+                .member(this)
+                .build();
+        this.markerList.add(markerAllocation);
+    }
+
+    public void addAvailableTime(AvailableTime availableTime) {
+        AvailableTimeAllocation availableTimeAllocation = AvailableTimeAllocation.builder()
+                .availableTime(availableTime)
+                .member(this)
+                .build();
+        this.availableTimeList.add(availableTimeAllocation);
+    }
+
+    public void addHobby(Hobby hobby) {
+        HobbyAllocation hobbyAllocation = HobbyAllocation.builder()
+                .hobby(hobby)
+                .member(this)
+                .build();
+        this.hobbyList.add(hobbyAllocation);
     }
 }

--- a/src/main/java/com/iglooclub/nungil/domain/Member.java
+++ b/src/main/java/com/iglooclub/nungil/domain/Member.java
@@ -128,6 +128,10 @@ public class Member {
 
     // == 비즈니스 로직 == //
 
+    /**
+     * 회원의 프로필 정보를 등록하는 메서드이다.
+     * @param request 프로필 등록 요청 DTO
+     */
     public void createProfile(ProfileCreateRequest request) {
         Contact newContact = Contact.builder()
                 .kakao(request.getContactKakao())
@@ -155,6 +159,15 @@ public class Member {
 
     }
 
+    /**
+     * 회원의 프로필 정보를 수정하는 메서드이다.
+     * @param request 프로필 수정 요청 DTO
+     * @param nonExistingFaceDepictions face_depiction_allocation 테이블의 행과 데이터가 겹치지 않는 추가적인 삽입 데이터 목록
+     * @param nonExistingPersonalityDepictions personality_depiction_allocation 테이블의 행과 데이터가 겹치지 않는 추가적인 삽입 데이터 목록
+     * @param nonExistingMarkers marker_allocation 테이블의 행과 데이터가 겹치지 않는 추가적인 삽입 데이터 목록
+     * @param nonExistingAvailableTimes available_time_allocation 테이블의 행과 데이터가 겹치지 않는 추가적인 삽입 데이터 목록
+     * @param nonExistingHobbies hobby_allocation 테이블의 행과 데이터가 겹치지 않는 추가적인 삽입 데이터 목록
+     */
     public void updateProfile(ProfileUpdateRequest request,
                               List<FaceDepictionAllocation> nonExistingFaceDepictions,
                               List<PersonalityDepictionAllocation> nonExistingPersonalityDepictions,

--- a/src/main/java/com/iglooclub/nungil/domain/Member.java
+++ b/src/main/java/com/iglooclub/nungil/domain/Member.java
@@ -10,6 +10,7 @@ import javax.persistence.*;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Entity
 @Getter
@@ -124,6 +125,8 @@ public class Member {
         this.locationList = new ArrayList<>();
     }
 
+    // == 비즈니스 로직 == //
+
     public void createProfile(ProfileCreateRequest request) {
         Contact newContact = Contact.builder()
                 .kakao(request.getContactKakao())
@@ -150,6 +153,40 @@ public class Member {
         request.getHobbyList().forEach(this::addHobby);
 
     }
+
+    // == 조회 로직 == //
+
+    public List<FaceDepiction> getFaceDepictionList() {
+        return this.faceDepictionAllocationList.stream()
+                .map(FaceDepictionAllocation::getFaceDepiction)
+                .collect(Collectors.toList());
+    }
+
+    public List<PersonalityDepiction> getPersonalityDepictionList() {
+        return this.personalityDepictionAllocationList.stream()
+                .map(PersonalityDepictionAllocation::getPersonalityDepiction)
+                .collect(Collectors.toList());
+    }
+
+    public List<Marker> getMarkerList() {
+        return this.markerAllocationList.stream()
+                .map(MarkerAllocation::getMarker)
+                .collect(Collectors.toList());
+    }
+
+    public List<AvailableTime> getAvailableTimeList() {
+        return this.availableTimeAllocationList.stream()
+                .map(AvailableTimeAllocation::getAvailableTime)
+                .collect(Collectors.toList());
+    }
+
+    public List<Hobby> getHobbyList() {
+        return this.hobbyAllocationList.stream()
+                .map(HobbyAllocation::getHobby)
+                .collect(Collectors.toList());
+    }
+
+    // == 연관관계 메서드 == //
 
     public void addFaceDepiction(FaceDepiction faceDepiction) {
         FaceDepictionAllocation faceDepictionAllocation = FaceDepictionAllocation.builder()

--- a/src/main/java/com/iglooclub/nungil/domain/Member.java
+++ b/src/main/java/com/iglooclub/nungil/domain/Member.java
@@ -63,11 +63,11 @@ public class Member {
 
     @Builder.Default
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<FaceDepictionAllocation> faceDepictionList = new ArrayList<>();
+    private List<FaceDepictionAllocation> faceDepictionAllocationList = new ArrayList<>();
 
     @Builder.Default
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<PersonalityDepictionAllocation> personalityDepictionList = new ArrayList<>();
+    private List<PersonalityDepictionAllocation> personalityDepictionAllocationList = new ArrayList<>();
 
     @Column(length = 400)
     private String description;
@@ -77,14 +77,14 @@ public class Member {
 
     @Builder.Default
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<AvailableTimeAllocation> availableTimeList = new ArrayList<>();
+    private List<AvailableTimeAllocation> availableTimeAllocationList = new ArrayList<>();
 
     @Builder.Default
     private Integer noshowCount = 0;
 
     @Builder.Default
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<HobbyAllocation> hobbyList = new ArrayList<>();
+    private List<HobbyAllocation> hobbyAllocationList = new ArrayList<>();
 
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private Contact contact;
@@ -103,7 +103,7 @@ public class Member {
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
-    private List<MarkerAllocation> markerList = new ArrayList<>();
+    private List<MarkerAllocation> markerAllocationList = new ArrayList<>();
 
     public Member update(String oauthAccess) {
         this.oauthAccess = oauthAccess;
@@ -113,14 +113,14 @@ public class Member {
     public Member(){
         this.point = 0;
         this.disableCompany = true;
-        this.availableTimeList = new ArrayList<>();
+        this.availableTimeAllocationList = new ArrayList<>();
         this.noshowCount = 0;
-        this.hobbyList = new ArrayList<>();
+        this.hobbyAllocationList = new ArrayList<>();
         this.nungilList = new ArrayList<>();
         this.acquaintanceList = new ArrayList<>();
-        this.faceDepictionList = new ArrayList<>();
-        this.personalityDepictionList = new ArrayList<>();
-        this.markerList = new ArrayList<>();
+        this.faceDepictionAllocationList = new ArrayList<>();
+        this.personalityDepictionAllocationList = new ArrayList<>();
+        this.markerAllocationList = new ArrayList<>();
         this.locationList = new ArrayList<>();
     }
 
@@ -156,7 +156,7 @@ public class Member {
                 .faceDepiction(faceDepiction)
                 .member(this)
                 .build();
-        this.faceDepictionList.add(faceDepictionAllocation);
+        this.faceDepictionAllocationList.add(faceDepictionAllocation);
     }
 
     public void addPersonalityDepiction(PersonalityDepiction personalityDepiction) {
@@ -164,7 +164,7 @@ public class Member {
                 .personalityDepiction(personalityDepiction)
                 .member(this)
                 .build();
-        this.personalityDepictionList.add(personalityDepictionAllocation);
+        this.personalityDepictionAllocationList.add(personalityDepictionAllocation);
     }
 
     public void addMarker(Marker marker) {
@@ -172,7 +172,7 @@ public class Member {
                 .marker(marker)
                 .member(this)
                 .build();
-        this.markerList.add(markerAllocation);
+        this.markerAllocationList.add(markerAllocation);
     }
 
     public void addAvailableTime(AvailableTime availableTime) {
@@ -180,7 +180,7 @@ public class Member {
                 .availableTime(availableTime)
                 .member(this)
                 .build();
-        this.availableTimeList.add(availableTimeAllocation);
+        this.availableTimeAllocationList.add(availableTimeAllocation);
     }
 
     public void addHobby(Hobby hobby) {
@@ -188,6 +188,6 @@ public class Member {
                 .hobby(hobby)
                 .member(this)
                 .build();
-        this.hobbyList.add(hobbyAllocation);
+        this.hobbyAllocationList.add(hobbyAllocation);
     }
 }

--- a/src/main/java/com/iglooclub/nungil/domain/PersonalityDepictionAllocation.java
+++ b/src/main/java/com/iglooclub/nungil/domain/PersonalityDepictionAllocation.java
@@ -1,0 +1,28 @@
+package com.iglooclub.nungil.domain;
+
+import com.iglooclub.nungil.domain.enums.PersonalityDepiction;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PersonalityDepictionAllocation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private PersonalityDepiction personalityDepiction;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+}

--- a/src/main/java/com/iglooclub/nungil/domain/enums/Alcohol.java
+++ b/src/main/java/com/iglooclub/nungil/domain/enums/Alcohol.java
@@ -6,12 +6,10 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum Alcohol {
-    NONE("마시지 않음"),
-    RARELY("어쩔 수 없을 때만"),
-    OCCASIONAL("가끔 마심"),
-    MODERATE("어느정도 즐김"),
-    ENJOY("좋아하는 편"),
-    HEAVY("술고래"),
+    NONE("비음주(금주)"),
+    OCCASIONAL("사회적 음주"),
+    MODERATE("월 4회 미만"),
+    HEAVY("월 5회 이상"),
     ;
 
     private final String title;

--- a/src/main/java/com/iglooclub/nungil/domain/enums/Hobby.java
+++ b/src/main/java/com/iglooclub/nungil/domain/enums/Hobby.java
@@ -1,4 +1,12 @@
 package com.iglooclub.nungil.domain.enums;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum Hobby {
+
+    ;
+    private final String title;
 }

--- a/src/main/java/com/iglooclub/nungil/domain/enums/Hobby.java
+++ b/src/main/java/com/iglooclub/nungil/domain/enums/Hobby.java
@@ -1,0 +1,4 @@
+package com.iglooclub.nungil.domain.enums;
+
+public enum Hobby {
+}

--- a/src/main/java/com/iglooclub/nungil/domain/enums/Marker.java
+++ b/src/main/java/com/iglooclub/nungil/domain/enums/Marker.java
@@ -1,4 +1,12 @@
 package com.iglooclub.nungil.domain.enums;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum Marker {
+
+    ;
+    private final String title;
 }

--- a/src/main/java/com/iglooclub/nungil/domain/enums/Religion.java
+++ b/src/main/java/com/iglooclub/nungil/domain/enums/Religion.java
@@ -6,11 +6,11 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum Religion {
-    NONE("무교"),
+    NONE("종교 없음"),
     CHRISTIANITY("기독교"),
     CATHOLICISM("천주교"),
     BUDDHISM("불교"),
-    OTHER("기타 종교"),
+    OTHER("기타"),
     ;
 
     private final String title;

--- a/src/main/java/com/iglooclub/nungil/domain/enums/Smoke.java
+++ b/src/main/java/com/iglooclub/nungil/domain/enums/Smoke.java
@@ -6,9 +6,9 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum Smoke {
-    SMOKER("흡연"),
-    NON_SMOKER("비흡연"),
-    E_CIGARETTE("전자담배"),
+    NONE("비흡연(금연)"),
+    OCCASIONAL("가끔 흡연"),
+    ALWAYS("매일 흡연"),
     ;
 
     private final String title;

--- a/src/main/java/com/iglooclub/nungil/dto/MemberDetailResponse.java
+++ b/src/main/java/com/iglooclub/nungil/dto/MemberDetailResponse.java
@@ -1,0 +1,90 @@
+package com.iglooclub.nungil.dto;
+
+import com.iglooclub.nungil.domain.Member;
+import com.iglooclub.nungil.domain.enums.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class MemberDetailResponse {
+    private String nickname;
+
+    private String sex;
+
+    private LocalDate birthdate;
+
+    private String contactKakao;
+
+    private String contactInstagram;
+
+    private String animalFace;
+
+    private String job;
+
+    private Integer height;
+
+    private Mbti mbti;
+
+    private String marriageState;
+
+    private String religion;
+
+    private String alcohol;
+
+    private String smoke;
+
+    private List<String> faceDepictionList;
+
+    private List<String> personalityDepictionList;
+
+    private String description;
+
+    private List<String> markerList;
+
+    private List<String> availableTimeList;
+
+    private List<String> hobbyList;
+
+    // == 생성 메서드 == //
+    public static MemberDetailResponse create(Member member) {
+        List<String> faceDepictionList = member.getFaceDepictionAllocationList().stream()
+                .map(v -> v.getFaceDepiction().getTitle()).collect(Collectors.toList());
+        List<String> personalityDepictionList = member.getPersonalityDepictionAllocationList().stream()
+                .map(v -> v.getPersonalityDepiction().getTitle()).collect(Collectors.toList());
+        List<String> markerList = member.getMarkerAllocationList().stream()
+                .map(v -> v.getMarker().getTitle()).collect(Collectors.toList());
+        List<String> availableTimeList = member.getAvailableTimeAllocationList().stream()
+                .map(v -> v.getAvailableTime().getTitle()).collect(Collectors.toList());
+        List<String> hobbyList = member.getHobbyAllocationList().stream()
+                .map(v -> v.getHobby().getTitle()).collect(Collectors.toList());
+
+        return MemberDetailResponse.builder()
+                .nickname(member.getNickname())
+                .sex(member.getSex().getTitle())
+                .birthdate(member.getBirthdate())
+                .contactKakao(member.getContact().getKakao())
+                .contactInstagram(member.getContact().getInstagram())
+                .animalFace(member.getAnimalFace().getTitle())
+                .job(member.getJob())
+                .height(member.getHeight())
+                .mbti(member.getMbti())
+                .marriageState(member.getMarriageState().getTitle())
+                .religion(member.getReligion().getTitle())
+                .alcohol(member.getAlcohol().getTitle())
+                .smoke(member.getSmoke().getTitle())
+                .faceDepictionList(faceDepictionList)
+                .personalityDepictionList(personalityDepictionList)
+                .description(member.getDescription())
+                .markerList(markerList)
+                .availableTimeList(availableTimeList)
+                .hobbyList(hobbyList)
+                .build();
+    }
+}

--- a/src/main/java/com/iglooclub/nungil/dto/ProfileCreateRequest.java
+++ b/src/main/java/com/iglooclub/nungil/dto/ProfileCreateRequest.java
@@ -1,0 +1,77 @@
+package com.iglooclub.nungil.dto;
+
+import com.iglooclub.nungil.domain.enums.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Past;
+import javax.validation.constraints.Size;
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ProfileCreateRequest {
+
+    @NotBlank
+    @Size(max = 8)
+    private String nickname;
+
+    @NotNull
+    private Sex sex;
+
+    @NotNull
+    @Past
+    private LocalDate birthdate;
+
+    @Size(max = 255)
+    private String contactKakao;
+
+    @Size(max = 255)
+    private String contactInstagram;
+
+    @NotNull
+    private AnimalFace animalFace;
+
+    @NotNull
+    @Size(max = 255)
+    private String job;
+
+    @NotNull
+    private Integer height;
+
+    @NotNull
+    private Mbti mbti;
+
+    @NotNull
+    private MarriageState marriageState;
+
+    @NotNull
+    private Religion religion;
+
+    @NotNull
+    private Alcohol alcohol;
+
+    @NotNull
+    private Smoke smoke;
+
+    @NotNull
+    private List<FaceDepiction> faceDepictionList;
+
+    @NotNull
+    private List<PersonalityDepiction> personalityDepictionList;
+
+    @NotNull
+    @Size(max = 300)
+    private String description;
+
+    private List<Marker> markerList;
+
+    private List<AvailableTime> availableTimeList;
+
+    private List<Hobby> hobbyList;
+}

--- a/src/main/java/com/iglooclub/nungil/dto/ProfileUpdateRequest.java
+++ b/src/main/java/com/iglooclub/nungil/dto/ProfileUpdateRequest.java
@@ -1,0 +1,77 @@
+package com.iglooclub.nungil.dto;
+
+import com.iglooclub.nungil.domain.enums.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Past;
+import javax.validation.constraints.Size;
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ProfileUpdateRequest {
+
+    @NotBlank
+    @Size(max = 8)
+    private String nickname;
+
+    @NotNull
+    private Sex sex;
+
+    @NotNull
+    @Past
+    private LocalDate birthdate;
+
+    @Size(max = 255)
+    private String contactKakao;
+
+    @Size(max = 255)
+    private String contactInstagram;
+
+    @NotNull
+    private AnimalFace animalFace;
+
+    @NotNull
+    @Size(max = 255)
+    private String job;
+
+    @NotNull
+    private Integer height;
+
+    @NotNull
+    private Mbti mbti;
+
+    @NotNull
+    private MarriageState marriageState;
+
+    @NotNull
+    private Religion religion;
+
+    @NotNull
+    private Alcohol alcohol;
+
+    @NotNull
+    private Smoke smoke;
+
+    @NotNull
+    private List<FaceDepiction> faceDepictionList;
+
+    @NotNull
+    private List<PersonalityDepiction> personalityDepictionList;
+
+    @NotNull
+    @Size(max = 300)
+    private String description;
+
+    private List<Marker> markerList;
+
+    private List<AvailableTime> availableTimeList;
+
+    private List<Hobby> hobbyList;
+}

--- a/src/main/java/com/iglooclub/nungil/repository/AvailableTimeAllocationRepository.java
+++ b/src/main/java/com/iglooclub/nungil/repository/AvailableTimeAllocationRepository.java
@@ -1,0 +1,16 @@
+package com.iglooclub.nungil.repository;
+
+import com.iglooclub.nungil.domain.AvailableTimeAllocation;
+import com.iglooclub.nungil.domain.enums.AvailableTime;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface AvailableTimeAllocationRepository extends JpaRepository<AvailableTimeAllocation, Long> {
+    @Modifying
+    @Query("delete from AvailableTimeAllocation f where f.availableTime not in :availableTimeList")
+    void deleteAllByAvailableTimeNotIn(@Param("availableTimeList") List<AvailableTime> availableTimeList);
+}

--- a/src/main/java/com/iglooclub/nungil/repository/AvailableTimeAllocationRepository.java
+++ b/src/main/java/com/iglooclub/nungil/repository/AvailableTimeAllocationRepository.java
@@ -1,6 +1,7 @@
 package com.iglooclub.nungil.repository;
 
 import com.iglooclub.nungil.domain.AvailableTimeAllocation;
+import com.iglooclub.nungil.domain.Member;
 import com.iglooclub.nungil.domain.enums.AvailableTime;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -13,4 +14,8 @@ public interface AvailableTimeAllocationRepository extends JpaRepository<Availab
     @Modifying
     @Query("delete from AvailableTimeAllocation f where f.availableTime not in :availableTimeList")
     void deleteAllByAvailableTimeNotIn(@Param("availableTimeList") List<AvailableTime> availableTimeList);
+
+    @Modifying
+    @Query("delete from AvailableTimeAllocation f where f.member = :member")
+    void deleteAllByMember(@Param("member") Member member);
 }

--- a/src/main/java/com/iglooclub/nungil/repository/FaceDepictionAllocationRepository.java
+++ b/src/main/java/com/iglooclub/nungil/repository/FaceDepictionAllocationRepository.java
@@ -1,6 +1,7 @@
 package com.iglooclub.nungil.repository;
 
 import com.iglooclub.nungil.domain.FaceDepictionAllocation;
+import com.iglooclub.nungil.domain.Member;
 import com.iglooclub.nungil.domain.enums.FaceDepiction;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -13,4 +14,8 @@ public interface FaceDepictionAllocationRepository extends JpaRepository<FaceDep
     @Modifying
     @Query("delete from FaceDepictionAllocation f where f.faceDepiction not in :faceDepictionList")
     void deleteAllByFaceDepictionNotIn(@Param("faceDepictionList") List<FaceDepiction> faceDepictionList);
+
+    @Modifying
+    @Query("delete from FaceDepictionAllocation f where f.member = :member")
+    void deleteAllByMember(@Param("member") Member member);
 }

--- a/src/main/java/com/iglooclub/nungil/repository/FaceDepictionAllocationRepository.java
+++ b/src/main/java/com/iglooclub/nungil/repository/FaceDepictionAllocationRepository.java
@@ -1,0 +1,16 @@
+package com.iglooclub.nungil.repository;
+
+import com.iglooclub.nungil.domain.FaceDepictionAllocation;
+import com.iglooclub.nungil.domain.enums.FaceDepiction;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface FaceDepictionAllocationRepository extends JpaRepository<FaceDepictionAllocation, Long> {
+    @Modifying
+    @Query("delete from FaceDepictionAllocation f where f.faceDepiction not in :faceDepictionList")
+    void deleteAllByFaceDepictionNotIn(@Param("faceDepictionList") List<FaceDepiction> faceDepictionList);
+}

--- a/src/main/java/com/iglooclub/nungil/repository/HobbyAllocationRepository.java
+++ b/src/main/java/com/iglooclub/nungil/repository/HobbyAllocationRepository.java
@@ -1,0 +1,16 @@
+package com.iglooclub.nungil.repository;
+
+import com.iglooclub.nungil.domain.HobbyAllocation;
+import com.iglooclub.nungil.domain.enums.Hobby;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface HobbyAllocationRepository extends JpaRepository<HobbyAllocation, Long> {
+    @Modifying
+    @Query("delete from HobbyAllocation f where f.hobby not in :hobbyList")
+    void deleteAllByHobbyNotIn(@Param("hobbyList") List<Hobby> hobbyList);
+}

--- a/src/main/java/com/iglooclub/nungil/repository/HobbyAllocationRepository.java
+++ b/src/main/java/com/iglooclub/nungil/repository/HobbyAllocationRepository.java
@@ -1,6 +1,7 @@
 package com.iglooclub.nungil.repository;
 
 import com.iglooclub.nungil.domain.HobbyAllocation;
+import com.iglooclub.nungil.domain.Member;
 import com.iglooclub.nungil.domain.enums.Hobby;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -13,4 +14,8 @@ public interface HobbyAllocationRepository extends JpaRepository<HobbyAllocation
     @Modifying
     @Query("delete from HobbyAllocation f where f.hobby not in :hobbyList")
     void deleteAllByHobbyNotIn(@Param("hobbyList") List<Hobby> hobbyList);
+
+    @Modifying
+    @Query("delete from HobbyAllocation f where f.member = :member")
+    void deleteAllByMember(@Param("member") Member member);
 }

--- a/src/main/java/com/iglooclub/nungil/repository/MarkerAllocationRepository.java
+++ b/src/main/java/com/iglooclub/nungil/repository/MarkerAllocationRepository.java
@@ -1,6 +1,7 @@
 package com.iglooclub.nungil.repository;
 
 import com.iglooclub.nungil.domain.MarkerAllocation;
+import com.iglooclub.nungil.domain.Member;
 import com.iglooclub.nungil.domain.enums.Marker;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -13,4 +14,8 @@ public interface MarkerAllocationRepository extends JpaRepository<MarkerAllocati
     @Modifying
     @Query("delete from MarkerAllocation f where f.marker not in :markerList")
     void deleteAllByMarkerNotIn(@Param("markerList") List<Marker> markerList);
+
+    @Modifying
+    @Query("delete from MarkerAllocation f where f.member = :member")
+    void deleteAllByMember(@Param("member") Member member);
 }

--- a/src/main/java/com/iglooclub/nungil/repository/MarkerAllocationRepository.java
+++ b/src/main/java/com/iglooclub/nungil/repository/MarkerAllocationRepository.java
@@ -1,0 +1,16 @@
+package com.iglooclub.nungil.repository;
+
+import com.iglooclub.nungil.domain.MarkerAllocation;
+import com.iglooclub.nungil.domain.enums.Marker;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface MarkerAllocationRepository extends JpaRepository<MarkerAllocation, Long> {
+    @Modifying
+    @Query("delete from MarkerAllocation f where f.marker not in :markerList")
+    void deleteAllByMarkerNotIn(@Param("markerList") List<Marker> markerList);
+}

--- a/src/main/java/com/iglooclub/nungil/repository/PersonalityDepictionAllocationRepository.java
+++ b/src/main/java/com/iglooclub/nungil/repository/PersonalityDepictionAllocationRepository.java
@@ -1,5 +1,6 @@
 package com.iglooclub.nungil.repository;
 
+import com.iglooclub.nungil.domain.Member;
 import com.iglooclub.nungil.domain.PersonalityDepictionAllocation;
 import com.iglooclub.nungil.domain.enums.PersonalityDepiction;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,4 +14,8 @@ public interface PersonalityDepictionAllocationRepository extends JpaRepository<
     @Modifying
     @Query("delete from PersonalityDepictionAllocation f where f.personalityDepiction not in :personalityDepictionList")
     void deleteAllByPersonalityDepictionNotIn(@Param("personalityDepictionList") List<PersonalityDepiction> personalityDepictionList);
+
+    @Modifying
+    @Query("delete from PersonalityDepictionAllocation f where f.member = :member")
+    void deleteAllByMember(@Param("member") Member member);
 }

--- a/src/main/java/com/iglooclub/nungil/repository/PersonalityDepictionAllocationRepository.java
+++ b/src/main/java/com/iglooclub/nungil/repository/PersonalityDepictionAllocationRepository.java
@@ -1,0 +1,16 @@
+package com.iglooclub.nungil.repository;
+
+import com.iglooclub.nungil.domain.PersonalityDepictionAllocation;
+import com.iglooclub.nungil.domain.enums.PersonalityDepiction;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface PersonalityDepictionAllocationRepository extends JpaRepository<PersonalityDepictionAllocation, Long> {
+    @Modifying
+    @Query("delete from PersonalityDepictionAllocation f where f.personalityDepiction not in :personalityDepictionList")
+    void deleteAllByPersonalityDepictionNotIn(@Param("personalityDepictionList") List<PersonalityDepiction> personalityDepictionList);
+}

--- a/src/main/java/com/iglooclub/nungil/service/MemberService.java
+++ b/src/main/java/com/iglooclub/nungil/service/MemberService.java
@@ -44,6 +44,13 @@ public class MemberService {
      */
     @Transactional
     public void createProfile(Member member, ProfileCreateRequest request) {
+        // == 데이터베이스 테이블에 프로필 데이터가 있다면 전부 삭제한다. == //
+        faceDepictionAllocationRepository.deleteAllByMember(member);
+        personalityDepictionAllocationRepository.deleteAllByMember(member);
+        markerAllocationRepository.deleteAllByMember(member);
+        availableTimeAllocationRepository.deleteAllByMember(member);
+        hobbyAllocationRepository.deleteAllByMember(member);
+
         member.createProfile(request);
     }
 

--- a/src/main/java/com/iglooclub/nungil/service/MemberService.java
+++ b/src/main/java/com/iglooclub/nungil/service/MemberService.java
@@ -57,46 +57,46 @@ public class MemberService {
         hobbyAllocationRepository.deleteAllByHobbyNotIn(request.getHobbyList());
 
         // 요청된 수정값들 중, 데이터베이스에 존재하지 않는 데이터들만을 삽입한다. //
-        List<FaceDepictionAllocation> newFaceDepictionAllocationList = new ArrayList<>();
+        List<FaceDepictionAllocation> nonExistingFaceDepictions = new ArrayList<>();
         for (FaceDepiction faceDepiction : request.getFaceDepictionList()) {
             if (!member.getFaceDepictionList().contains(faceDepiction)) {
-                newFaceDepictionAllocationList.add(FaceDepictionAllocation.builder()
+                nonExistingFaceDepictions.add(FaceDepictionAllocation.builder()
                         .faceDepiction(faceDepiction).member(member).build());
             }
         }
 
-        List<PersonalityDepictionAllocation> newPersonalityDepictionAllocationList = new ArrayList<>();
+        List<PersonalityDepictionAllocation> nonExistingPersonalityDepictions = new ArrayList<>();
         for (PersonalityDepiction personalityDepiction : request.getPersonalityDepictionList()) {
             if (!member.getPersonalityDepictionList().contains(personalityDepiction)) {
-                newPersonalityDepictionAllocationList.add(PersonalityDepictionAllocation.builder()
+                nonExistingPersonalityDepictions.add(PersonalityDepictionAllocation.builder()
                         .personalityDepiction(personalityDepiction).member(member).build());
             }
         }
 
-        List<MarkerAllocation> newMarkerAllocationList = new ArrayList<>();
+        List<MarkerAllocation> nonExistingMarkers = new ArrayList<>();
         for (Marker marker : request.getMarkerList()) {
             if (!member.getMarkerList().contains(marker)) {
-                newMarkerAllocationList.add(MarkerAllocation.builder()
+                nonExistingMarkers.add(MarkerAllocation.builder()
                         .marker(marker).member(member).build());
             }
         }
 
-        List<AvailableTimeAllocation> newAvailableTimeAllocationList = new ArrayList<>();
+        List<AvailableTimeAllocation> nonExistingAvailableTimes = new ArrayList<>();
         for (AvailableTime availableTime : request.getAvailableTimeList()) {
             if (!member.getAvailableTimeList().contains(availableTime)) {
-                newAvailableTimeAllocationList.add(AvailableTimeAllocation.builder()
+                nonExistingAvailableTimes.add(AvailableTimeAllocation.builder()
                         .availableTime(availableTime).member(member).build());
             }
         }
 
-        List<HobbyAllocation> newHobbyAllocationList = new ArrayList<>();
+        List<HobbyAllocation> nonExistingHobbies = new ArrayList<>();
         for (Hobby hobby : request.getHobbyList()) {
             if (!member.getHobbyList().contains(hobby)) {
-                newHobbyAllocationList.add(HobbyAllocation.builder()
+                nonExistingHobbies.add(HobbyAllocation.builder()
                         .hobby(hobby).member(member).build());
             }
         }
 
-        member.updateProfile(request, newFaceDepictionAllocationList, newPersonalityDepictionAllocationList, newMarkerAllocationList, newAvailableTimeAllocationList, newHobbyAllocationList);
+        member.updateProfile(request, nonExistingFaceDepictions, nonExistingPersonalityDepictions, nonExistingMarkers, nonExistingAvailableTimes, nonExistingHobbies);
     }
 }

--- a/src/main/java/com/iglooclub/nungil/service/MemberService.java
+++ b/src/main/java/com/iglooclub/nungil/service/MemberService.java
@@ -37,26 +37,41 @@ public class MemberService {
                 .orElseThrow(() -> new GeneralException(MemberErrorResult.USER_NOT_FOUND));
     }
 
+    /**
+     * 주어진 회원의 프로필 정보를 등록하는 메서드이다.
+     * @param member 프로필 정보가 등록되지 않은 회원
+     * @param request 프로필 등록 요청 DTO
+     */
     @Transactional
     public void createProfile(Member member, ProfileCreateRequest request) {
         member.createProfile(request);
     }
 
+    /**
+     * 회원 정보를 조회하는 메서드이다.
+     * @param member 정보를 조회할 회원의 Member 클래스
+     * @return 회원 정보 응답 DTO
+     */
     public MemberDetailResponse getMemberDetail(Member member) {
         return MemberDetailResponse.create(member);
     }
 
+    /**
+     * 주어진 회원의 프로필 정보를 수정하는 메서드이다.
+     * @param member 프로필 정보가 이미 등록된 회원
+     * @param request 프로필 수정 요청 DTO
+     */
     @Transactional
     public void updateProfile(Member member, ProfileUpdateRequest request) {
 
-        // 데이터베이스의 데이터들 중, 요청된 수정값이 아닌 값들을 모두 삭제한다. //
+        // == 데이터베이스의 데이터들 중, 요청된 수정값이 아닌 값들을 모두 삭제한다. == //
         faceDepictionAllocationRepository.deleteAllByFaceDepictionNotIn(request.getFaceDepictionList());
         personalityDepictionAllocationRepository.deleteAllByPersonalityDepictionNotIn(request.getPersonalityDepictionList());
         markerAllocationRepository.deleteAllByMarkerNotIn(request.getMarkerList());
         availableTimeAllocationRepository.deleteAllByAvailableTimeNotIn(request.getAvailableTimeList());
         hobbyAllocationRepository.deleteAllByHobbyNotIn(request.getHobbyList());
 
-        // 요청된 수정값들 중, 데이터베이스에 존재하지 않는 데이터들만을 삽입한다. //
+        // == 요청된 수정값들 중, 데이터베이스에 존재하지 않는 데이터들만을 삽입한다. == //
         List<FaceDepictionAllocation> nonExistingFaceDepictions = new ArrayList<>();
         for (FaceDepiction faceDepiction : request.getFaceDepictionList()) {
             if (!member.getFaceDepictionList().contains(faceDepiction)) {

--- a/src/main/java/com/iglooclub/nungil/service/MemberService.java
+++ b/src/main/java/com/iglooclub/nungil/service/MemberService.java
@@ -1,14 +1,19 @@
 package com.iglooclub.nungil.service;
 
-import com.iglooclub.nungil.domain.Member;
+import com.iglooclub.nungil.domain.*;
+import com.iglooclub.nungil.domain.enums.*;
 import com.iglooclub.nungil.dto.MemberDetailResponse;
 import com.iglooclub.nungil.dto.ProfileCreateRequest;
+import com.iglooclub.nungil.dto.ProfileUpdateRequest;
 import com.iglooclub.nungil.exception.GeneralException;
 import com.iglooclub.nungil.exception.MemberErrorResult;
-import com.iglooclub.nungil.repository.MemberRepository;
+import com.iglooclub.nungil.repository.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @RequiredArgsConstructor
 @Service
@@ -16,6 +21,16 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+
+    private final FaceDepictionAllocationRepository faceDepictionAllocationRepository;
+
+    private final PersonalityDepictionAllocationRepository personalityDepictionAllocationRepository;
+
+    private final MarkerAllocationRepository markerAllocationRepository;
+
+    private final AvailableTimeAllocationRepository availableTimeAllocationRepository;
+
+    private final HobbyAllocationRepository hobbyAllocationRepository;
 
     public Member findById(Long memberId) {
         return memberRepository.findById(memberId)
@@ -29,5 +44,59 @@ public class MemberService {
 
     public MemberDetailResponse getMemberDetail(Member member) {
         return MemberDetailResponse.create(member);
+    }
+
+    @Transactional
+    public void updateProfile(Member member, ProfileUpdateRequest request) {
+
+        // 데이터베이스의 데이터들 중, 요청된 수정값이 아닌 값들을 모두 삭제한다. //
+        faceDepictionAllocationRepository.deleteAllByFaceDepictionNotIn(request.getFaceDepictionList());
+        personalityDepictionAllocationRepository.deleteAllByPersonalityDepictionNotIn(request.getPersonalityDepictionList());
+        markerAllocationRepository.deleteAllByMarkerNotIn(request.getMarkerList());
+        availableTimeAllocationRepository.deleteAllByAvailableTimeNotIn(request.getAvailableTimeList());
+        hobbyAllocationRepository.deleteAllByHobbyNotIn(request.getHobbyList());
+
+        // 요청된 수정값들 중, 데이터베이스에 존재하지 않는 데이터들만을 삽입한다. //
+        List<FaceDepictionAllocation> newFaceDepictionAllocationList = new ArrayList<>();
+        for (FaceDepiction faceDepiction : request.getFaceDepictionList()) {
+            if (!member.getFaceDepictionList().contains(faceDepiction)) {
+                newFaceDepictionAllocationList.add(FaceDepictionAllocation.builder()
+                        .faceDepiction(faceDepiction).member(member).build());
+            }
+        }
+
+        List<PersonalityDepictionAllocation> newPersonalityDepictionAllocationList = new ArrayList<>();
+        for (PersonalityDepiction personalityDepiction : request.getPersonalityDepictionList()) {
+            if (!member.getPersonalityDepictionList().contains(personalityDepiction)) {
+                newPersonalityDepictionAllocationList.add(PersonalityDepictionAllocation.builder()
+                        .personalityDepiction(personalityDepiction).member(member).build());
+            }
+        }
+
+        List<MarkerAllocation> newMarkerAllocationList = new ArrayList<>();
+        for (Marker marker : request.getMarkerList()) {
+            if (!member.getMarkerList().contains(marker)) {
+                newMarkerAllocationList.add(MarkerAllocation.builder()
+                        .marker(marker).member(member).build());
+            }
+        }
+
+        List<AvailableTimeAllocation> newAvailableTimeAllocationList = new ArrayList<>();
+        for (AvailableTime availableTime : request.getAvailableTimeList()) {
+            if (!member.getAvailableTimeList().contains(availableTime)) {
+                newAvailableTimeAllocationList.add(AvailableTimeAllocation.builder()
+                        .availableTime(availableTime).member(member).build());
+            }
+        }
+
+        List<HobbyAllocation> newHobbyAllocationList = new ArrayList<>();
+        for (Hobby hobby : request.getHobbyList()) {
+            if (!member.getHobbyList().contains(hobby)) {
+                newHobbyAllocationList.add(HobbyAllocation.builder()
+                        .hobby(hobby).member(member).build());
+            }
+        }
+
+        member.updateProfile(request, newFaceDepictionAllocationList, newPersonalityDepictionAllocationList, newMarkerAllocationList, newAvailableTimeAllocationList, newHobbyAllocationList);
     }
 }

--- a/src/main/java/com/iglooclub/nungil/service/MemberService.java
+++ b/src/main/java/com/iglooclub/nungil/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.iglooclub.nungil.service;
 
 import com.iglooclub.nungil.domain.Member;
+import com.iglooclub.nungil.dto.ProfileCreateRequest;
 import com.iglooclub.nungil.exception.GeneralException;
 import com.iglooclub.nungil.exception.MemberErrorResult;
 import com.iglooclub.nungil.repository.MemberRepository;
@@ -18,5 +19,10 @@ public class MemberService {
     public Member findById(Long memberId) {
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> new GeneralException(MemberErrorResult.USER_NOT_FOUND));
+    }
+
+    @Transactional
+    public void createProfile(Member member, ProfileCreateRequest request) {
+        member.createProfile(request);
     }
 }

--- a/src/main/java/com/iglooclub/nungil/service/MemberService.java
+++ b/src/main/java/com/iglooclub/nungil/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.iglooclub.nungil.service;
 
 import com.iglooclub.nungil.domain.Member;
+import com.iglooclub.nungil.dto.MemberDetailResponse;
 import com.iglooclub.nungil.dto.ProfileCreateRequest;
 import com.iglooclub.nungil.exception.GeneralException;
 import com.iglooclub.nungil.exception.MemberErrorResult;
@@ -24,5 +25,9 @@ public class MemberService {
     @Transactional
     public void createProfile(Member member, ProfileCreateRequest request) {
         member.createProfile(request);
+    }
+
+    public MemberDetailResponse getMemberDetail(Member member) {
+        return MemberDetailResponse.create(member);
     }
 }


### PR DESCRIPTION
## 🔥 Related Issues

- close #8 

## 💜 작업 내용

- [x] 회원 프로필 등록
- [x] 회원 정보 수정
- [x] 회원 정보 조회

## ✅ PR Point

### 회원 프로필 등록

- Member 클래스 내부에서 프로필 등록 시에 호출하는 createProfile 메서드를 구현했습니다.
- `contact` 는 초기에 null 이기 때문에 새로 생성하여 대입했습니다.
- `faceDepictionAllocationList`, `personalityDepictionAllocationList`, `markerAllocationList`, `availableTimeAllocationList`, `hobbyAllocationList` 는 초기에 빈 배열이기 때문에, 생성 메서드를 반복했습니다.

```java
public void createProfile(ProfileCreateRequest request) {

    this.nickname = request.getNickname();
    this.sex = request.getSex();
    this.birthdate = request.getBirthdate();
    this.contact.update(request.getContactKakao(), request.getContactInstagram());
    this.animalFace = request.getAnimalFace();
    this.job = request.getJob();
    this.height = request.getHeight();
    this.mbti = request.getMbti();
    this.marriageState = request.getMarriageState();
    this.religion = request.getReligion();
    this.alcohol = request.getAlcohol();
    this.smoke = request.getSmoke();
    request.getFaceDepictionList().forEach(this::addFaceDepiction);
    request.getPersonalityDepictionList().forEach(this::addPersonalityDepiction);
    this.description = request.getDescription();
    request.getMarkerList().forEach(this::addMarker);
    request.getAvailableTimeList().forEach(this::addAvailableTime);
    request.getHobbyList().forEach(this::addHobby);
}
```

### 회원 정보 수정

- Member 클래스 내부에서 프로필 수정 시에 호출하는 updateProfile 메서드를 구현했습니다.
- 데이터베이스에 존재하지 않는 데이터만을 삽입하기 위해, 이에 해당하는 데이터만 포함한 리스트를 파라미터로 받았습니다.

```java
public void updateProfile(ProfileUpdateRequest request,
                          List<FaceDepictionAllocation> nonExistingFaceDepictions,
                          List<PersonalityDepictionAllocation> nonExistingPersonalityDepictions,
                          List<MarkerAllocation> nonExistingMarkers,
                          List<AvailableTimeAllocation> nonExistingAvailableTimes,
                          List<HobbyAllocation> nonExistingHobbies) {

    this.nickname = request.getNickname();
    this.sex = request.getSex();
    this.birthdate = request.getBirthdate();
    this.contact.update(request.getContactKakao(), request.getContactInstagram());
    this.animalFace = request.getAnimalFace();
    this.job = request.getJob();
    this.height = request.getHeight();
    this.mbti = request.getMbti();
    this.marriageState = request.getMarriageState();
    this.religion = request.getReligion();
    this.alcohol = request.getAlcohol();
    this.smoke = request.getSmoke();
    this.description = request.getDescription();

    this.faceDepictionAllocationList = nonExistingFaceDepictions;

    this.personalityDepictionAllocationList = nonExistingPersonalityDepictions;

    this.markerAllocationList = nonExistingMarkers;

    this.availableTimeAllocationList = nonExistingAvailableTimes;

    this.hobbyAllocationList = nonExistingHobbies;
}
```

### 회원 정보 조회

- Enum 클래스에 title 필드를 두어, 각 Enum 값에 해당하는 문자열을 반환하도록 하였습니다.

```java
public static MemberDetailResponse create(Member member) {
    List<String> faceDepictionList = member.getFaceDepictionAllocationList().stream()
            .map(v -> v.getFaceDepiction().getTitle()).collect(Collectors.toList());
    List<String> personalityDepictionList = member.getPersonalityDepictionAllocationList().stream()
            .map(v -> v.getPersonalityDepiction().getTitle()).collect(Collectors.toList());
    List<String> markerList = member.getMarkerAllocationList().stream()
            .map(v -> v.getMarker().getTitle()).collect(Collectors.toList());
    List<String> availableTimeList = member.getAvailableTimeAllocationList().stream()
            .map(v -> v.getAvailableTime().getTitle()).collect(Collectors.toList());
    List<String> hobbyList = member.getHobbyAllocationList().stream()
            .map(v -> v.getHobby().getTitle()).collect(Collectors.toList());

    return MemberDetailResponse.builder()
            .nickname(member.getNickname())
            .sex(member.getSex().getTitle())
            .birthdate(member.getBirthdate())
            .contactKakao(member.getContact().getKakao())
            .contactInstagram(member.getContact().getInstagram())
            .animalFace(member.getAnimalFace().getTitle())
            .job(member.getJob())
            .height(member.getHeight())
            .mbti(member.getMbti())
            .marriageState(member.getMarriageState().getTitle())
            .religion(member.getReligion().getTitle())
            .alcohol(member.getAlcohol().getTitle())
            .smoke(member.getSmoke().getTitle())
            .faceDepictionList(faceDepictionList)
            .personalityDepictionList(personalityDepictionList)
            .description(member.getDescription())
            .markerList(markerList)
            .availableTimeList(availableTimeList)
            .hobbyList(hobbyList)
            .build();
}
```

### 기타

- 피그마 상의 회원가입에서 동일 회사 차단 여부 입력란이 없어서, Member 엔티티의 해당하는 필드를 참으로 초기화했습니다.

```java
public class Member {
    @Builder.Default
    private Boolean disableCompany = true;
```

## 😡 Trouble Shooting

1. **orphanRemoval 옵션으로 설정된 컬렉션을 연관관계로 가지는 경우, 컬렉션이 empty가 아닐때 참조 인스턴스를 변경하면 오류가 발생합니다.**
    - 기존엔 일대다 관계의 객체 생명 주기가 같은 엔티티 리스트에 `@OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)` 적용
    - 회원 수정 메서드에서 해당 엔티티 리스트의 참조 인스턴스를 변경할 때 오류 발생 (e.g. `this.faceDepictionAllocationList = nonExistingFaceDepictions;`)
    
    - ![image](https://github.com/Igloo-Club/Igloo-Club-BE/assets/50361496/3e850c17-5875-4547-90a9-9ad0ff5e6f7f)

    - `orphanRemoval = true` 코드 제거

2. **일대다 관계의 엔티티 리스트 수정 방식**
    - 회원 정보 수정 방식에서 여러 후보가 있었습니다. 설명를 위해 `List<HobbyAllocation> hobbyAllocationList` 만으로 간략화하겠습니다.
    1. **데이터베이스에서 모든 HobbyAllocation 행 삭제 후, 수정 요청의 Hobby 목록 삽입**
        - 예를 들어 데이터베이스에 ["MOVIE", "MUSIC", "SOCCER"] 가 존재하고, 수정 요청에 ["MOVIE", "SLEEP"] 이 있는 경우
            1. ["MOVIE", "MUSIC", "SOCCER"] 삭제
            2. ["MOVIE", "SLEEP"] 삽입
        - 장점: 이해하기 간단하고, 실수로 인한 버그가 나올 가능성이 적음
        - 단점: INSERT 쿼리 자주 발생
    2. **데이터베이스에서 수정 요청에 포함되지 않는 행들 삭제 후, 수정 요청에서 겹치지 않는 Hobby 목록만 삽입**
        - 예를 들어 데이터베이스에 ["MOVIE", "MUSIC", "SOCCER"] 가 존재하고, 수정 요청에 ["MOVIE", "SLEEP"] 이 있는 경우
            1. ["MUSIC", "SOCCER"] 삭제
            2. ["SLEEP"] 삽입
        - 장점: 상대적으로 적은 쿼리 발생
        - 단점: 이해하기 어렵고, 후에 실수로 버그가 생길 가능성 높음
    - 일단은 후자로 구현했는데, 아직도 뭐가 맞는지 모르겠네요.

## ☀ 스크린샷 / GIF / 화면 녹화

## 📚 Reference

- [[JPA-Hibernate] orphanRemoval 옵션 사용시 Collection 참조를 변경하지 말자](https://jerry92k.tistory.com/44)
