### PR TITLE
[feat] CORS 설정에서 AllowedOrigins 변경

### DIFF
--- a/src/main/java/com/iglooclub/nungil/config/RedisConfig.java
+++ b/src/main/java/com/iglooclub/nungil/config/RedisConfig.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 
@@ -16,9 +17,14 @@ public class RedisConfig {
     @Value("${spring.redis.port}")
     private int port;
 
+    @Value("${spring.redis.password}")
+    private String password;
+
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
-        return new LettuceConnectionFactory(host, port);
+        RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration(host, port);
+        configuration.setPassword(password);
+        return new LettuceConnectionFactory(configuration);
     }
 
     @Bean

--- a/src/main/java/com/iglooclub/nungil/config/SecurityConfig.java
+++ b/src/main/java/com/iglooclub/nungil/config/SecurityConfig.java
@@ -79,7 +79,7 @@ public class SecurityConfig {
         CorsConfiguration config = new CorsConfiguration();
 
         config.setAllowedOrigins(
-                List.of("http://localhost:8080", "http://localhost:3000")
+                List.of("http://localhost:8080", "http://localhost:3000", "http://localhost:5173")
         );
         config.setAllowedMethods(
                 List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")


### PR DESCRIPTION
## 🔥 Related Issues

- close #20 

## 💜 작업 내용

- [x] 허용 Origins 목록 변경
- [x] Redis에서 비밀번호를 입력받도록 수정

## ✅ PR Point

- 허용 Origins에 프론트 개발 URL을 추가했습니다.
- EC2 서버에 Redis를 실행시킴에 따라, 공격 방지를 위해 비밀번호를 설정했습니다.

## 😡 Trouble Shooting

- EC2 상에서 프로젝트 빌드가 너무 오래 걸렸습니다.
- 때문에 스왑 공간에 메모리를 일부 할당했습니다.

## 📚 Reference

- [AWS EC2에 Redis 생성 & Spring boot 연동법](https://aossuper8.tistory.com/288)
- [[AWS] Swap File을 이용해 EC2 메모리 부족 현상을 해결해보자](https://kth990303.tistory.com/361)
