### PR TITLE
[feat] 채팅 기능 일부 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,9 @@ dependencies {
 
     // coolsms
     implementation 'net.nurigo:sdk:4.3.0'
+
+    // websocket & stomp
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/iglooclub/nungil/config/WebSocketConfig.java
+++ b/src/main/java/com/iglooclub/nungil/config/WebSocketConfig.java
@@ -1,6 +1,10 @@
 package com.iglooclub.nungil.config;
 
+import com.iglooclub.nungil.config.jwt.ChatPreHandler;
+import com.iglooclub.nungil.exception.ChatErrorHandler;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
@@ -12,13 +16,20 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
  */
 @Configuration
 @EnableWebSocketMessageBroker
+@RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final ChatPreHandler chatPreHandler;
+
+    private final ChatErrorHandler chatErrorHandler;
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry
                 .addEndpoint("/stomp")
-                .setAllowedOrigins("*");
+                .setAllowedOriginPatterns("*")
+                .withSockJS();
+        registry.setErrorHandler(chatErrorHandler);
     }
 
     @Override
@@ -26,5 +37,10 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
         registry.enableSimpleBroker("/topic");
         registry.setApplicationDestinationPrefixes("/chat");
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(chatPreHandler);
     }
 }

--- a/src/main/java/com/iglooclub/nungil/config/WebSocketConfig.java
+++ b/src/main/java/com/iglooclub/nungil/config/WebSocketConfig.java
@@ -1,0 +1,30 @@
+package com.iglooclub.nungil.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+/**
+ * 웹 소켓 설정 클래스입니다.
+ * WebSocket과 Stomp 프로토콜을 이용한 메시징을 활성화합니다.
+ */
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry
+                .addEndpoint("/stomp")
+                .setAllowedOrigins("*");
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+
+        registry.enableSimpleBroker("/topic");
+        registry.setApplicationDestinationPrefixes("/chat");
+    }
+}

--- a/src/main/java/com/iglooclub/nungil/config/jwt/ChatPreHandler.java
+++ b/src/main/java/com/iglooclub/nungil/config/jwt/ChatPreHandler.java
@@ -1,0 +1,47 @@
+package com.iglooclub.nungil.config.jwt;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageDeliveryException;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class ChatPreHandler implements ChannelInterceptor {
+
+    private final TokenProvider tokenProvider;
+    private final static String HEADER_AUTHORIZATION = "Authorization";
+    private final static String TOKEN_PREFIX = "Bearer ";
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(message);
+
+        // 요청 헤더의 Authorization 키의 값 조회
+        String authorizationHeader = String.valueOf(headerAccessor.getNativeHeader(HEADER_AUTHORIZATION));
+        // 가져온 값에서 접두사 제거
+        String token = getAccessToken(authorizationHeader);
+        // 가져온 토큰이 유효한지 확인하고, 유효한 때는 인증 정보 설정
+        if (tokenProvider.validateToken(token)) {
+            Authentication authentication = tokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        } else {
+            // ChatErrorHandler 클래스에서 처리하는 예외와 에러 메시지가 "UNAUTHORIZED"로 동일해야 한다.
+            throw new MessageDeliveryException("UNAUTHORIZED");
+        }
+
+        return message;
+    }
+
+    private String getAccessToken(String authorizationHeader) {
+        if (authorizationHeader != null && authorizationHeader.startsWith(TOKEN_PREFIX)) {
+            return authorizationHeader.substring(TOKEN_PREFIX.length());
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/iglooclub/nungil/controller/ChatMessageController.java
+++ b/src/main/java/com/iglooclub/nungil/controller/ChatMessageController.java
@@ -2,12 +2,21 @@ package com.iglooclub.nungil.controller;
 
 import com.iglooclub.nungil.domain.Member;
 import com.iglooclub.nungil.dto.ChatDTO;
+import com.iglooclub.nungil.dto.ChatMessageListResponse;
 import com.iglooclub.nungil.service.ChatMessageService;
 import com.iglooclub.nungil.service.MemberService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.security.Principal;
@@ -29,6 +38,21 @@ public class ChatMessageController {
         ChatDTO mappedChat = chatMessageService.save(chatDTO, member);
 
         messagingTemplate.convertAndSend("/topic/" + chatDTO.getChatRoomId(), mappedChat);
+    }
+
+    @GetMapping("/api/chat/room/{chatRoomId}")
+    public ResponseEntity<Slice<ChatMessageListResponse>> getMessageSlice(@PathVariable Long chatRoomId,
+                                                                          @RequestParam(defaultValue = "0") int pageNumber,
+                                                                          @RequestParam(defaultValue = "12") int pageSize,
+                                                                          Principal principal) {
+
+        Member member = getMember(principal);
+        // 메시지를 최근에 작성된 순서대로 조회
+        PageRequest pageRequest = PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Order.desc("createdAt")));
+
+        Slice<ChatMessageListResponse> messageSlice = chatMessageService.getMessageSlice(chatRoomId, member, pageRequest);
+
+        return new ResponseEntity<>(messageSlice, HttpStatus.OK);
     }
 
     private Member getMember(Principal principal) {

--- a/src/main/java/com/iglooclub/nungil/controller/ChatMessageController.java
+++ b/src/main/java/com/iglooclub/nungil/controller/ChatMessageController.java
@@ -1,0 +1,37 @@
+package com.iglooclub.nungil.controller;
+
+import com.iglooclub.nungil.domain.Member;
+import com.iglooclub.nungil.dto.ChatDTO;
+import com.iglooclub.nungil.service.ChatMessageService;
+import com.iglooclub.nungil.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.security.Principal;
+
+@RestController
+@RequiredArgsConstructor
+public class ChatMessageController {
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    private final ChatMessageService chatMessageService;
+
+    private final MemberService memberService;
+
+    @MessageMapping("/send")
+    public void send(@Payload ChatDTO chatDTO, Principal principal) {
+        Member member = getMember(principal);
+
+        ChatDTO mappedChat = chatMessageService.save(chatDTO, member);
+
+        messagingTemplate.convertAndSend("/topic/" + chatDTO.getChatRoomId(), mappedChat);
+    }
+
+    private Member getMember(Principal principal) {
+        return memberService.findById(Long.parseLong(principal.getName()));
+    }
+}

--- a/src/main/java/com/iglooclub/nungil/domain/ChatMessage.java
+++ b/src/main/java/com/iglooclub/nungil/domain/ChatMessage.java
@@ -1,5 +1,6 @@
 package com.iglooclub.nungil.domain;
 
+import com.iglooclub.nungil.domain.enums.ChatMessageStatus;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -28,6 +29,10 @@ public class ChatMessage {
 
     @Column(length = 400)
     private String content;
+
+    // 개발의 편의를 위해 일단 기본값을 READ로 설정. 추후 읽지 않은 메시지 개발 시 UNREAD로 변경
+    @Column(name = "status")
+    private ChatMessageStatus status = ChatMessageStatus.READ;
 
     private LocalDateTime createdAt;
 }

--- a/src/main/java/com/iglooclub/nungil/domain/ChatMessage.java
+++ b/src/main/java/com/iglooclub/nungil/domain/ChatMessage.java
@@ -1,10 +1,7 @@
 package com.iglooclub.nungil.domain;
 
 import com.iglooclub.nungil.domain.enums.ChatMessageStatus;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -35,4 +32,14 @@ public class ChatMessage {
     private ChatMessageStatus status = ChatMessageStatus.READ;
 
     private LocalDateTime createdAt;
+
+    public static ChatMessage create(ChatRoom chatRoom, Member member, String content) {
+        ChatMessage chatMessage = new ChatMessage();
+        chatMessage.chatRoom = chatRoom;
+        chatMessage.member = member;
+        chatMessage.content = content;
+        chatMessage.createdAt = LocalDateTime.now();
+
+        return chatMessage;
+    }
 }

--- a/src/main/java/com/iglooclub/nungil/domain/ChatMessage.java
+++ b/src/main/java/com/iglooclub/nungil/domain/ChatMessage.java
@@ -29,6 +29,7 @@ public class ChatMessage {
 
     // 개발의 편의를 위해 일단 기본값을 READ로 설정. 추후 읽지 않은 메시지 개발 시 UNREAD로 변경
     @Column(name = "status")
+    @Enumerated(EnumType.STRING)
     private ChatMessageStatus status = ChatMessageStatus.READ;
 
     private LocalDateTime createdAt;

--- a/src/main/java/com/iglooclub/nungil/domain/ChatMessage.java
+++ b/src/main/java/com/iglooclub/nungil/domain/ChatMessage.java
@@ -1,0 +1,33 @@
+package com.iglooclub.nungil.domain;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatMessage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chatroom_id")
+    private ChatRoom chatRoom;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Column(length = 400)
+    private String content;
+
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/iglooclub/nungil/domain/ChatRoom.java
+++ b/src/main/java/com/iglooclub/nungil/domain/ChatRoom.java
@@ -1,9 +1,6 @@
 package com.iglooclub.nungil.domain;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -12,6 +9,7 @@ import java.util.List;
 
 @Entity
 @Getter
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ChatRoom {
@@ -28,8 +26,18 @@ public class ChatRoom {
     @JoinColumn(name = "receiver_id")
     private Member receiver;
 
+    @Builder.Default
     @OneToMany(mappedBy = "chatRoom")
     List<ChatMessage> chatMessageList = new ArrayList();
 
     private LocalDateTime createdAt;
+
+    // == 생성 메서드 == //
+    public static ChatRoom create(Member receiver, Member sender) {
+        return ChatRoom.builder()
+                .sender(sender)
+                .receiver(receiver)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
 }

--- a/src/main/java/com/iglooclub/nungil/domain/ChatRoom.java
+++ b/src/main/java/com/iglooclub/nungil/domain/ChatRoom.java
@@ -1,0 +1,35 @@
+package com.iglooclub.nungil.domain;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatRoom {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sender_id")
+    private Member sender;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "receiver_id")
+    private Member receiver;
+
+    @OneToMany(mappedBy = "chatRoom")
+    List<ChatMessage> chatMessageList = new ArrayList();
+
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/iglooclub/nungil/domain/enums/ChatMessageStatus.java
+++ b/src/main/java/com/iglooclub/nungil/domain/enums/ChatMessageStatus.java
@@ -1,0 +1,6 @@
+package com.iglooclub.nungil.domain.enums;
+
+public enum ChatMessageStatus {
+    READ,
+    UNREAD,
+}

--- a/src/main/java/com/iglooclub/nungil/dto/ChatDTO.java
+++ b/src/main/java/com/iglooclub/nungil/dto/ChatDTO.java
@@ -1,0 +1,26 @@
+package com.iglooclub.nungil.dto;
+
+import com.iglooclub.nungil.domain.ChatMessage;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ChatDTO {
+
+    private Long chatRoomId;
+    private String sender;
+    private String content;
+    private LocalDateTime createdAt;
+
+    public static ChatDTO of(Long chatRoomId, String nickname, ChatMessage chatMessage) {
+        return new ChatDTO(chatRoomId,
+                nickname,
+                chatMessage.getContent(),
+                chatMessage.getCreatedAt());
+    }
+}

--- a/src/main/java/com/iglooclub/nungil/dto/ChatMessageListResponse.java
+++ b/src/main/java/com/iglooclub/nungil/dto/ChatMessageListResponse.java
@@ -1,0 +1,31 @@
+package com.iglooclub.nungil.dto;
+
+import com.iglooclub.nungil.domain.ChatMessage;
+import com.iglooclub.nungil.domain.Member;
+import com.iglooclub.nungil.domain.enums.AnimalFace;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ChatMessageListResponse {
+
+    private AnimalFace animalFace;
+
+    private String sender;
+
+    private String content;
+
+    private LocalDateTime createdAt;
+
+    private Boolean isSender;
+
+    public static ChatMessageListResponse create(Member member, ChatMessage chatMessage, Boolean isSender) {
+        return new ChatMessageListResponse(member.getAnimalFace(), member.getNickname(), chatMessage.getContent(),
+                chatMessage.getCreatedAt(), isSender);
+    }
+}

--- a/src/main/java/com/iglooclub/nungil/exception/ChatErrorHandler.java
+++ b/src/main/java/com/iglooclub/nungil/exception/ChatErrorHandler.java
@@ -1,0 +1,38 @@
+package com.iglooclub.nungil.exception;
+
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.StompSubProtocolErrorHandler;
+
+import java.nio.charset.StandardCharsets;
+
+@Component
+public class ChatErrorHandler extends StompSubProtocolErrorHandler {
+
+    @Override
+    public Message<byte[]> handleClientMessageProcessingError(Message<byte[]> clientMessage, Throwable ex) {
+
+        if ("UNAUTHORIZED".equals(ex.getMessage())) {
+            return makeErrorMessage(TokenErrorResult.UNEXPECTED_TOKEN);
+        }
+
+        return super.handleClientMessageProcessingError(clientMessage, ex);
+    }
+
+    // 메세지 생성
+    private Message<byte[]> makeErrorMessage(ErrorResult errorResult)
+    {
+
+        String message = String.valueOf(errorResult.getMessage());
+
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.ERROR);
+
+        accessor.setMessage(String.valueOf(errorResult.name()));
+        accessor.setLeaveMutable(true);
+
+        return MessageBuilder.createMessage(message.getBytes(StandardCharsets.UTF_8), accessor.getMessageHeaders());
+    }
+}

--- a/src/main/java/com/iglooclub/nungil/exception/ChatRoomErrorResult.java
+++ b/src/main/java/com/iglooclub/nungil/exception/ChatRoomErrorResult.java
@@ -1,0 +1,17 @@
+package com.iglooclub.nungil.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ChatRoomErrorResult implements ErrorResult {
+
+    CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "Failed to find the chat room"),
+    NOT_MEMBER(HttpStatus.FORBIDDEN, "Only available for the member of the chat room"),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/iglooclub/nungil/repository/ChatMessageRepository.java
+++ b/src/main/java/com/iglooclub/nungil/repository/ChatMessageRepository.java
@@ -1,7 +1,12 @@
 package com.iglooclub.nungil.repository;
 
 import com.iglooclub.nungil.domain.ChatMessage;
+import com.iglooclub.nungil.domain.ChatRoom;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+
+    Slice<ChatMessage> findByChatRoom(PageRequest pageRequest, ChatRoom chatRoom);
 }

--- a/src/main/java/com/iglooclub/nungil/repository/ChatMessageRepository.java
+++ b/src/main/java/com/iglooclub/nungil/repository/ChatMessageRepository.java
@@ -1,0 +1,7 @@
+package com.iglooclub.nungil.repository;
+
+import com.iglooclub.nungil.domain.ChatMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+}

--- a/src/main/java/com/iglooclub/nungil/repository/ChatRoomRepository.java
+++ b/src/main/java/com/iglooclub/nungil/repository/ChatRoomRepository.java
@@ -1,0 +1,7 @@
+package com.iglooclub.nungil.repository;
+
+import com.iglooclub.nungil.domain.ChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+}

--- a/src/main/java/com/iglooclub/nungil/service/ChatMessageService.java
+++ b/src/main/java/com/iglooclub/nungil/service/ChatMessageService.java
@@ -1,0 +1,58 @@
+package com.iglooclub.nungil.service;
+
+import com.iglooclub.nungil.domain.ChatMessage;
+import com.iglooclub.nungil.domain.ChatRoom;
+import com.iglooclub.nungil.domain.Member;
+import com.iglooclub.nungil.dto.ChatDTO;
+import com.iglooclub.nungil.exception.ChatRoomErrorResult;
+import com.iglooclub.nungil.exception.GeneralException;
+import com.iglooclub.nungil.repository.ChatMessageRepository;
+import com.iglooclub.nungil.repository.ChatRoomRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ChatMessageService {
+
+    private final ChatRoomRepository chatRoomRepository;
+
+    private final ChatMessageRepository chatMessageRepository;
+
+    /**
+     * 채팅 메시지를 데이터베이스에 저장하는 메서드입니다.
+     * @param chatDTO 발행된 채팅 메시지 DTO
+     * @param member 메시지 발행자 정보
+     * @return 기존의 발행된 메시지에서 데이터가 추가된 DTO
+     */
+    @Transactional
+    public ChatDTO save(ChatDTO chatDTO, Member member) {
+
+        ChatRoom chatRoom = chatRoomRepository.findById(chatDTO.getChatRoomId())
+                .orElseThrow(() -> new GeneralException(ChatRoomErrorResult.CHAT_ROOM_NOT_FOUND));
+
+        // 메시지 발행자(member)가 해당 채팅방의 일원이 아니면 예외 발생
+        if (!checkChatRoomMember(chatRoom, member)) {
+            throw new GeneralException(ChatRoomErrorResult.NOT_MEMBER);
+        }
+
+        // 데이터베이스에 채팅 메시지 저장
+        ChatMessage chatMessage = ChatMessage.create(chatRoom, member, chatDTO.getContent());
+        chatMessageRepository.save(chatMessage);
+
+        return ChatDTO.of(chatDTO.getChatRoomId(), member.getNickname(), chatMessage);
+    }
+
+    /**
+     * 사용자가 주어진 채팅방의 일원인지 확인한다.
+     * @param chatRoom 채팅방
+     * @param member 확인할 사용자
+     * @return 채팅방에 속해있는지 여부
+     */
+    private boolean checkChatRoomMember(ChatRoom chatRoom, Member member) {
+        Long memberId = member.getId();
+        return memberId.equals(chatRoom.getReceiver().getId()) || memberId.equals(chatRoom.getSender().getId());
+    }
+}

--- a/src/main/java/com/iglooclub/nungil/service/NungilService.java
+++ b/src/main/java/com/iglooclub/nungil/service/NungilService.java
@@ -9,6 +9,7 @@ import com.iglooclub.nungil.dto.*;
 import com.iglooclub.nungil.exception.GeneralException;
 import com.iglooclub.nungil.exception.NungilErrorResult;
 import com.iglooclub.nungil.repository.AcquaintanceRepository;
+import com.iglooclub.nungil.repository.ChatRoomRepository;
 import com.iglooclub.nungil.repository.MemberRepository;
 import com.iglooclub.nungil.repository.NungilRepository;
 import lombok.RequiredArgsConstructor;
@@ -31,6 +32,8 @@ public class NungilService {
     private final MemberRepository memberRepository;
     private final NungilRepository nungilRepository;
     private final AcquaintanceRepository acquaintanceRepository;
+
+    private final ChatRoomRepository chatRoomRepository;
 
     private final MemberService memberService;
 
@@ -210,6 +213,10 @@ public class NungilService {
         }
         receivedNungil.update(marker, time, yoil);
         sentNungil.update(marker, time, yoil);
+
+        // 매칭된 사용자들을 채팅방에 초대
+        ChatRoom chatRoom = ChatRoom.create(member, sender);
+        chatRoomRepository.save(chatRoom);
     }
 
     /**


### PR DESCRIPTION
## 🔥 Related Issues

- close #24

## 💜 작업 내용

- [x] 채팅방 생성
- [x] 채팅 보내기
- [x] 특정 채팅방의 채팅 내역 조회

### 🙏 미완이라 미안

- [ ] 특정 사용자에게 연결된 모든 채팅방 목록 조회
- [ ] 일주일 뒤에 채팅방 삭제

## ✅ PR Point

### 1️⃣ 채팅방 생성

매칭 성사 시에 두 사람이 포함된 채팅방을 생성합니다.

<div><var>service/NungilService.java</var></div>

```java
@Transactional
public void matchNungil(Long nungilId){
    ...
    // 매칭된 사용자들을 채팅방에 초대
    ChatRoom chatRoom = ChatRoom.create(member, sender);
    chatRoomRepository.save(chatRoom);
}
```

### 2️⃣ 채팅 보내기

**(중요) 테스트할 방법이 마땅치 않아서, 실제로 잘 되는지 모르겠어요.**

- 프론트엔드에서 `topic/{채팅방 ID}` 를 구독(subscribe)한 이후

- `ws://경로/chat/send` 로 요청을 보내면, 해당 채팅방을 구독 중인 다른 클라이언트들에게 메시지가 전송됩니다.

<div><var>controller/ChatMessageController.java</var></div>

```java
@MessageMapping("/send")
public void send(@Payload ChatDTO chatDTO, Principal principal) {
    Member member = getMember(principal);

    ChatDTO mappedChat = chatMessageService.save(chatDTO, member);

    messagingTemplate.convertAndSend("/topic/" + chatDTO.getChatRoomId(), mappedChat);
}
```

- 이때, 요청 헤더에 포함된 액세스 토큰을 사용하여 유효한 사용자인지 확인합니다.

- 때문에 프론트엔드는 STOMP 요청 헤더에 `Authorization`으로 액세스 토큰을 보내야 합니다.

<div><var>config/jwt/ChatPreHandler.java</var></div>

```java
public class ChatPreHandler implements ChannelInterceptor {
    ...
    @Override
    public Message<?> preSend(Message<?> message, MessageChannel channel) {
        StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(message);

        // 요청 헤더의 Authorization 키의 값 조회
        String authorizationHeader = String.valueOf(headerAccessor.getNativeHeader(HEADER_AUTHORIZATION));
        // 가져온 값에서 접두사 제거
        String token = getAccessToken(authorizationHeader);
        // 가져온 토큰이 유효한지 확인하고, 유효한 때는 인증 정보 설정
        if (tokenProvider.validateToken(token)) {
            Authentication authentication = tokenProvider.getAuthentication(token);
            SecurityContextHolder.getContext().setAuthentication(authentication);
        } else {
            // ChatErrorHandler 클래스에서 처리하는 예외와 에러 메시지가 "UNAUTHORIZED"로 동일해야 한다.
            throw new MessageDeliveryException("UNAUTHORIZED");
        }

        return message;
    }
}

```

### 3️⃣ 특정 채팅방의 채팅 내역 조회

- 주어진 채팅방에서 최근에 작성된 순서대로 채팅 메시지 목록을 조회합니다.

<div><var>controller/ChatMessageController.java</var></div>

```java
@GetMapping("/api/chat/room/{chatRoomId}")
public ResponseEntity<Slice<ChatMessageListResponse>> getMessageSlice(@PathVariable Long chatRoomId,
                                                                      @RequestParam(defaultValue = "0") int pageNumber,
                                                                      @RequestParam(defaultValue = "12") int pageSize,
                                                                      Principal principal) {

    Member member = getMember(principal);
    // 메시지를 최근에 작성된 순서대로 조회
    PageRequest pageRequest = PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Order.desc("createdAt")));

    Slice<ChatMessageListResponse> messageSlice = chatMessageService.getMessageSlice(chatRoomId, member, pageRequest);

    return new ResponseEntity<>(messageSlice, HttpStatus.OK);
}
```

<div><var>service/ChatMessageService.java</var></div>

```java
public Slice<ChatMessageListResponse> getMessageSlice(Long chatRoomId, Member member, PageRequest pageRequest) {
    ChatRoom chatRoom = getChatRoom(chatRoomId);

    // 메시지 발행자(member)가 해당 채팅방의 일원이 아니면 예외 발생
    if (!checkChatRoomMember(chatRoom, member)) {
        throw new GeneralException(ChatRoomErrorResult.NOT_MEMBER);
    }

    // 주어진 채팅방의 메시지들을 pageRequest에 맞추어 조회
    Slice<ChatMessage> messageSlice = chatMessageRepository.findByChatRoom(pageRequest, chatRoom);

    // 메시지들을 DTO 리스트로 변환
    List<ChatMessageListResponse> responseList = messageSlice.getContent().stream()
            .map(chatMessage -> {
                Member sender = chatMessage.getMember();
                Boolean isSender = member.getId().equals(sender.getId());

                return ChatMessageListResponse.create(sender, chatMessage, isSender);
            }).collect(Collectors.toList());

    // 변환된 DTO 리스트와 함께 새로운 Slice 객체를 생성하여 반환
    return new SliceImpl<>(responseList, pageRequest, messageSlice.hasNext());
}
```

## 😡 Trouble Shooting

### 1️⃣ 특정 사용자에게 연결된 모든 채팅방 목록 조회

- **조회 데이터**
    1. 상대방 동물상
    2. 상대방 닉네임
    3. 최근 채팅 메시지 (상대방/본인 상관 없음)
    4. 채팅방 ID
- **정렬 조건**
    1. 최근 채팅 메시지가 생성된 순서

이걸 고려해서 QueryDSL 코드를 짜야 하는데 실패했습니다...

### 2️⃣ 일주일 뒤에 채팅방 삭제

- 채팅방에 생성일 두었으니 이를 활용해서 삭제하면 될 듯 합니다.

## 📚 Reference

- [[캡스톤디자인] Spring Boot, STOMP를 이용한 Chatting 구현 (3)](https://velog.io/@sanizzang00/%EC%BA%A1%EC%8A%A4%ED%86%A4%EB%94%94%EC%9E%90%EC%9D%B8-Spring-Boot-STOMP%EB%A5%BC-%EC%9D%B4%EC%9A%A9%ED%95%9C-Chatting-%EA%B5%AC%ED%98%84-3#dto-%EC%BD%94%EB%93%9C-%EA%B5%AC%ED%98%84)
- [채팅 (STOMP + JWT)](https://velog.io/@jkijki12/%EC%B1%84%ED%8C%85-STOMP-JWT#api-%EB%B3%B4%EC%95%88%EC%9D%80)
- [[Spring/WebSocket] WebSocket 도입과 STOMP subscribe, send 인가 구현](https://ppaksang.tistory.com/18)
