### PR TITLE
 [feat] 채팅방 상대방 가능 시간 장소 열람 기능 추가

### DIFF
--- a/src/main/java/com/iglooclub/nungil/controller/ChatMessageController.java
+++ b/src/main/java/com/iglooclub/nungil/controller/ChatMessageController.java
@@ -1,6 +1,7 @@
 package com.iglooclub.nungil.controller;
 
 import com.iglooclub.nungil.domain.Member;
+import com.iglooclub.nungil.dto.AvailableTimeAndPlaceResponse;
 import com.iglooclub.nungil.dto.ChatDTO;
 import com.iglooclub.nungil.dto.ChatMessageListResponse;
 import com.iglooclub.nungil.dto.ChatRoomListResponse;
@@ -67,6 +68,12 @@ public class ChatMessageController {
         Slice<ChatRoomListResponse> roomSlice = chatMessageService.getChatRoomSlice(member, pageRequest);
 
         return new ResponseEntity<>(roomSlice, HttpStatus.OK);
+    }
+
+    @GetMapping("/api/chat/room/{chatRoomId}/info")
+    public AvailableTimeAndPlaceResponse getAvailableTimeAndPlace(@PathVariable Long chatRoomId, Principal principal){
+        Member member = getMember(principal);
+        return chatMessageService.getAvailableTimeAndPlace(member, chatRoomId);
     }
 
     private Member getMember(Principal principal) {

--- a/src/main/java/com/iglooclub/nungil/dto/AvailableTimeAndPlaceResponse.java
+++ b/src/main/java/com/iglooclub/nungil/dto/AvailableTimeAndPlaceResponse.java
@@ -1,0 +1,17 @@
+package com.iglooclub.nungil.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class AvailableTimeAndPlaceResponse {
+
+    private String yoil;
+
+    private String time;
+
+    private String marker;
+}

--- a/src/main/java/com/iglooclub/nungil/dto/NungilMatchResponse.java
+++ b/src/main/java/com/iglooclub/nungil/dto/NungilMatchResponse.java
@@ -11,7 +11,10 @@ import lombok.Getter;
 @AllArgsConstructor
 @Builder
 public class NungilMatchResponse {
-    String yoil;
-    String time;
-    String marker;
+
+    private String yoil;
+
+    private String time;
+
+    private String marker;
 }

--- a/src/main/java/com/iglooclub/nungil/service/ChatMessageService.java
+++ b/src/main/java/com/iglooclub/nungil/service/ChatMessageService.java
@@ -1,12 +1,11 @@
 package com.iglooclub.nungil.service;
 
-import com.iglooclub.nungil.domain.ChatMessage;
-import com.iglooclub.nungil.domain.ChatRoom;
-import com.iglooclub.nungil.domain.Member;
+import com.iglooclub.nungil.domain.*;
 import com.iglooclub.nungil.domain.enums.AnimalFace;
-import com.iglooclub.nungil.dto.ChatDTO;
-import com.iglooclub.nungil.dto.ChatMessageListResponse;
-import com.iglooclub.nungil.dto.ChatRoomListResponse;
+import com.iglooclub.nungil.domain.enums.AvailableTime;
+import com.iglooclub.nungil.domain.enums.Marker;
+import com.iglooclub.nungil.domain.enums.Yoil;
+import com.iglooclub.nungil.dto.*;
 import com.iglooclub.nungil.exception.ChatRoomErrorResult;
 import com.iglooclub.nungil.exception.GeneralException;
 import com.iglooclub.nungil.repository.ChatMessageRepository;
@@ -144,4 +143,32 @@ public class ChatMessageService {
             );
         });
     }
+    /**
+     * 사용자의 채팅방 목록을 Slice 형식으로 조회하는 메서드입니다.
+     * @param member 조회를 요청한 회원의 엔티티
+     * @param chatRoomId 채팅방 id
+     * @return AvailableTimeAndPlaceResponse 상대방의 가능한 시간과 장소
+     */
+    public AvailableTimeAndPlaceResponse getAvailableTimeAndPlace(Member member, Long chatRoomId){
+        ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
+                .orElseThrow(()-> new GeneralException(ChatRoomErrorResult.CHAT_ROOM_NOT_FOUND));
+        Member opponent = chatRoom.getSender().equals(member) ? chatRoom.getReceiver() : chatRoom.getSender();
+        List<AvailableTime> timeList = opponent.getAvailableTimeAllocationList().stream()
+                .map(AvailableTimeAllocation::getAvailableTime)
+                .collect(Collectors.toList());
+
+        List<Marker> markersList = opponent.getMarkerAllocationList().stream()
+                .map(MarkerAllocation::getMarker)
+                .collect(Collectors.toList());
+
+        List<Yoil> yoilList = opponent.getYoilList();
+
+        return new AvailableTimeAndPlaceResponse(
+                yoilList.toString(),
+                timeList.toString(),
+                markersList.toString()
+        );
+    }
+
+
 }


### PR DESCRIPTION
## 🔥 Related Issues

- close #38 

## 💜 작업 내용

- [x] chatRoomId를 path Variable로 받아 AvailableTimeAndPlaceResponse를 반환합니다

## ✅ PR Point

- AvailableTimeAndPlaceResponse
```
public class AvailableTimeAndPlaceResponse {

    private String yoil;

    private String time;

    private String marker;
}
```
- 해당 메서드로 처리
```
public AvailableTimeAndPlaceResponse getAvailableTimeAndPlace(Member member, Long chatRoomId){
        ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
                .orElseThrow(()-> new GeneralException(ChatRoomErrorResult.CHAT_ROOM_NOT_FOUND));
        Member opponent = chatRoom.getSender().equals(member) ? chatRoom.getReceiver() : chatRoom.getSender();
        List<AvailableTime> timeList = opponent.getAvailableTimeAllocationList().stream()
                .map(AvailableTimeAllocation::getAvailableTime)
                .collect(Collectors.toList());

        List<Marker> markersList = opponent.getMarkerAllocationList().stream()
                .map(MarkerAllocation::getMarker)
                .collect(Collectors.toList());

        List<Yoil> yoilList = opponent.getYoilList();

        return new AvailableTimeAndPlaceResponse(
                yoilList.toString(),
                timeList.toString(),
                markersList.toString()
        );
    }
```

## ☀ 스크린샷 / GIF / 화면 녹화

![image](https://github.com/Igloo-Club/Igloo-Club-BE/assets/106146847/0bd2e48c-c49e-4360-9228-792c6aeba200)
