### PR TITLE
[fix] 인연 프로필 추천 로직 수정

### DIFF
--- a/src/main/java/com/iglooclub/nungil/domain/Acquaintance.java
+++ b/src/main/java/com/iglooclub/nungil/domain/Acquaintance.java
@@ -1,17 +1,13 @@
 package com.iglooclub.nungil.domain;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import com.iglooclub.nungil.domain.enums.AcquaintanceStatus;
+import lombok.*;
 
 import javax.persistence.*;
 
 @Entity
 @Getter
-@Builder
-@AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Acquaintance {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -24,4 +20,24 @@ public class Acquaintance {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "acquaintance_member_id")
     private Member acquaintanceMember;
+
+    @Enumerated(EnumType.STRING)
+    private AcquaintanceStatus status;
+
+    // == 생성 메서드 == //
+    public static Acquaintance create(Member member, Member acquaintanceMember, AcquaintanceStatus status) {
+        Acquaintance acquaintance = new Acquaintance();
+
+        acquaintance.member = member;
+        acquaintance.acquaintanceMember = acquaintanceMember;
+        acquaintance.status = status;
+
+        return acquaintance;
+    }
+
+    // == 비즈니스 로직 == //
+
+    public void update(AcquaintanceStatus status) {
+        this.status = status;
+    }
 }

--- a/src/main/java/com/iglooclub/nungil/domain/enums/AcquaintanceStatus.java
+++ b/src/main/java/com/iglooclub/nungil/domain/enums/AcquaintanceStatus.java
@@ -1,0 +1,8 @@
+package com.iglooclub.nungil.domain.enums;
+
+public enum AcquaintanceStatus {
+    RECEIVED,
+    SENT,
+    MATCHED,
+    RECOMMENDED,
+}

--- a/src/main/java/com/iglooclub/nungil/dto/NungilSliceResponse.java
+++ b/src/main/java/com/iglooclub/nungil/dto/NungilSliceResponse.java
@@ -1,25 +1,47 @@
 package com.iglooclub.nungil.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
+import com.iglooclub.nungil.domain.Company;
+import com.iglooclub.nungil.domain.Member;
+import com.iglooclub.nungil.domain.Nungil;
+import com.iglooclub.nungil.domain.enums.AnimalFace;
+import lombok.*;
+
 import java.time.LocalDateTime;
 
 @Getter
-@AllArgsConstructor
-@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class NungilSliceResponse {
-    private final Long nungilId;
+    private Long nungilId;
 
-    private final String animalFace;
+    private String animalFace;
 
-    private final String companyName;
+    private String companyName;
 
-    private final String job;
+    private String job;
 
-    private final String description;
+    private String description;
 
-    private final LocalDateTime createdAt;
+    private LocalDateTime createdAt;
 
-    private final LocalDateTime expiredAt;
+    private LocalDateTime expiredAt;
+
+    private String nickname;
+
+    public static NungilSliceResponse create(Nungil nungil, Member member) {
+        NungilSliceResponse response = new NungilSliceResponse();
+        AnimalFace animalFace = member.getAnimalFace();
+        Company company = member.getCompany();
+
+        response.nungilId = nungil.getId();
+        response.createdAt = nungil.getCreatedAt();
+        response.expiredAt = nungil.getExpiredAt();
+
+        response.animalFace = (animalFace != null) ? animalFace.getTitle() : null;
+        response.companyName = (company != null) ? company.getCompanyName() : null;
+        response.job = member.getJob();
+        response.description = member.getDescription();
+        response.nickname = member.getNickname();
+
+        return response;
+    }
 }

--- a/src/main/java/com/iglooclub/nungil/exception/NungilErrorResult.java
+++ b/src/main/java/com/iglooclub/nungil/exception/NungilErrorResult.java
@@ -10,7 +10,9 @@ public enum NungilErrorResult implements ErrorResult{
     NUNGIL_NOT_FOUND(HttpStatus.NOT_FOUND, "Failed to find the Nungil"),
     NUNGIL_WRONG_STATUS(HttpStatus.BAD_REQUEST, "Nungil's status is not correct"),
     NUNGIL_MORE_THAN_ONE(HttpStatus.INTERNAL_SERVER_ERROR, "More than one Nungil from same Sender"),
-    NUNGIL_NO_RECOMMEND(HttpStatus.NOT_FOUND,"Have no recommendation");
+    NUNGIL_NO_RECOMMEND(HttpStatus.NOT_FOUND,"Have no recommendation"),
+    LIMIT_EXCEEDED(HttpStatus.FORBIDDEN, "You have exceeded the limit")
+    ;
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/iglooclub/nungil/repository/AcquaintanceRepository.java
+++ b/src/main/java/com/iglooclub/nungil/repository/AcquaintanceRepository.java
@@ -2,7 +2,12 @@ package com.iglooclub.nungil.repository;
 
 import com.iglooclub.nungil.domain.Acquaintance;
 import com.iglooclub.nungil.domain.Member;
+import com.iglooclub.nungil.domain.enums.AcquaintanceStatus;
+import com.iglooclub.nungil.domain.enums.NungilStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -11,4 +16,8 @@ public interface AcquaintanceRepository extends JpaRepository<Acquaintance, Long
     List<Acquaintance> findByMember(Member member);
 
     Optional<Acquaintance> findByMemberAndAcquaintanceMember(Member member, Member acquaintanceMember);
+
+    @Modifying
+    @Query("delete from Acquaintance a where a.status = :status")
+    void deleteAllByStatus(@Param("status") AcquaintanceStatus status);
 }

--- a/src/main/java/com/iglooclub/nungil/repository/AcquaintanceRepository.java
+++ b/src/main/java/com/iglooclub/nungil/repository/AcquaintanceRepository.java
@@ -5,7 +5,10 @@ import com.iglooclub.nungil.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface AcquaintanceRepository extends JpaRepository<Acquaintance, Long> {
     List<Acquaintance> findByMember(Member member);
+
+    Optional<Acquaintance> findByMemberAndAcquaintanceMember(Member member, Member acquaintanceMember);
 }

--- a/src/main/java/com/iglooclub/nungil/repository/NungilRepository.java
+++ b/src/main/java/com/iglooclub/nungil/repository/NungilRepository.java
@@ -27,4 +27,6 @@ public interface NungilRepository extends JpaRepository<Nungil, Long> {
     @Modifying
     @Query("delete from Nungil n where n.expiredAt <= :dateTime")
     void deleteAllByExpiredAtBefore(@Param("dateTime") LocalDateTime dateTime);
+
+    Long countByMemberAndStatus(Member member, NungilStatus status);
 }

--- a/src/main/java/com/iglooclub/nungil/repository/NungilRepository.java
+++ b/src/main/java/com/iglooclub/nungil/repository/NungilRepository.java
@@ -6,6 +6,9 @@ import com.iglooclub.nungil.domain.enums.NungilStatus;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -16,7 +19,12 @@ public interface NungilRepository extends JpaRepository<Nungil, Long> {
     Optional<Nungil> findById(Long nungilId);
     Optional<Nungil> findFirstByMemberAndReceiver(Member member, Member receiver);
     List<Nungil> findAllByMemberAndReceiverAndStatus(Member member,Member receiver,NungilStatus status);
-    List<Nungil> findByExpiredAtBefore(LocalDateTime dateTime);
-    List<Nungil> findByStatus(NungilStatus status);
 
+    @Modifying
+    @Query("delete from Nungil n where n.status = :status")
+    void deleteAllByStatus(@Param("status") NungilStatus status);
+
+    @Modifying
+    @Query("delete from Nungil n where n.expiredAt <= :dateTime")
+    void deleteAllByExpiredAtBefore(@Param("dateTime") LocalDateTime dateTime);
 }

--- a/src/main/java/com/iglooclub/nungil/service/NungilService.java
+++ b/src/main/java/com/iglooclub/nungil/service/NungilService.java
@@ -114,15 +114,7 @@ public class NungilService {
 
         // Nungil 엔티티를 NungilPageResponse DTO로 변환
         List<NungilSliceResponse> nungilResponses = nungilSlice.getContent().stream()
-                .map(nungil -> NungilSliceResponse.builder()
-                        .nungilId(nungil.getId())
-                        .animalFace(nungil.getReceiver().getAnimalFace().getTitle())
-                        .companyName(nungil.getReceiver().getCompany().getCompanyName()) // 이 부분은 Nungil 엔티티의 구조에 따라 달라질 수 있습니다.
-                        .job(nungil.getReceiver().getJob())
-                        .description(nungil.getReceiver().getDescription())
-                        .createdAt(nungil.getCreatedAt())
-                        .expiredAt(nungil.getExpiredAt())
-                        .build())
+                .map(nungil -> NungilSliceResponse.create(nungil, nungil.getReceiver()))
                 .collect(Collectors.toList());
 
         // 변환된 DTO 리스트와 함께 새로운 Slice 객체를 생성하여 반환
@@ -148,7 +140,6 @@ public class NungilService {
      * receiver에게 status가 RECEIVED인 눈길을 생성합니다
      *
      * @param nungilId 눈길 id
-     * @return nungilResponse 특정 눈길 정보
      */
     @Transactional
     public void sendNungil(Member member, Long nungilId){

--- a/src/main/java/com/iglooclub/nungil/service/NungilService.java
+++ b/src/main/java/com/iglooclub/nungil/service/NungilService.java
@@ -244,14 +244,15 @@ public class NungilService {
     }
 
     /**
-     * 매일 오전 11시에 추천된 눈길을 삭제합니다
-     *
+     * 매일 오전 11시에 추천된 눈길을 삭제하고,
+     * 전날에 추천되었던 회원이 다시 추천될 수 있도록 합니다.
      *
      */
     @Scheduled(cron = "0 0 11 * * *") // 매일 오전 11시에 실행
     @Transactional
     public void deleteRecommendedNungils() {
         nungilRepository.deleteAllByStatus(NungilStatus.RECOMMENDED);
+        acquaintanceRepository.deleteAllByStatus(AcquaintanceStatus.RECOMMENDED);
     }
 
     private Member getMember(Principal principal) {

--- a/src/main/java/com/iglooclub/nungil/service/NungilService.java
+++ b/src/main/java/com/iglooclub/nungil/service/NungilService.java
@@ -246,10 +246,7 @@ public class NungilService {
     @Transactional
     public void deleteExpiredNungils() {
         LocalDateTime now = LocalDateTime.now();
-        List<Nungil> expiredNungils = nungilRepository.findByExpiredAtBefore(now);
-        for (Nungil nungil : expiredNungils) {
-            nungilRepository.delete(nungil);
-        }
+        nungilRepository.deleteAllByExpiredAtBefore(now);
     }
     /**
      * 매일 오전 11시에 추천된 눈길을 삭제합니다
@@ -259,11 +256,7 @@ public class NungilService {
     @Scheduled(cron = "0 0 11 * * *") // 매일 오전 11시에 실행
     @Transactional
     public void deleteRecommendedNungils() {
-        LocalDateTime now = LocalDateTime.now();
-        List<Nungil> recommendedNungils = nungilRepository.findByStatus(NungilStatus.RECOMMENDED);
-        for (Nungil nungil : recommendedNungils) {
-            nungilRepository.delete(nungil);
-        }
+        nungilRepository.deleteAllByStatus(NungilStatus.RECOMMENDED);
     }
 
 


### PR DESCRIPTION
## 🔥 Related Issues

- close #42 

## 💜 작업 내용

- [x] Acquaintance 객체 생애 주기 변경
- [x] 프로필 추천 로직 수정
- [x] 눈길 목록 조회 데이터에 닉네임 추가
- [x] 인스턴스 생성 메서드 추가 및 다른 방식으로의 생성 제한
- [x] 데이터베이스 쿼리 최적화

## ✅ PR Point

### 1️⃣ Acquaintance 객체 생애 주기 변경

- '인연 프로필 뽑기'의 추가 횟수가 하루 두 번으로 수정됨에 따라 `Acquaintance`의 생애 주기가 변경되었습니다.
- `Acquaintance` 클래스의 필드로 "어느 시점에 생성된 것인지"를 나타내는 `AcquaintanceStatus`가 추가되었습니다.

```
1. '인연 프로필 뽑기' 성공 시에 `Acquaintance(본인, 상대방, RECOMMENDED)` 저장
2. '매칭 성사' 시에 `Acquaintance(본인, 상대방, MATCHED)`와 `Acquaintance(상대방, 본인, MATCHED)` 저장
3. 매일 11시에 '모든 Acquaintance(RECOMMENDED) 삭제'
```

또한 매 추천마다 동일한 구성(member, recommendedMember)의 Acquaintance가 쌓였기 때문에 생성 로직을 일부 수정했습니다.

```java
private Acquaintance getAcquaintance(Member member, Member acquaintanceMember) {
    return acquaintanceRepository.findByMemberAndAcquaintanceMember(member, acquaintanceMember)
            .orElse(Acquaintance.create(member, acquaintanceMember, AcquaintanceStatus.RECOMMENDED));
}
```

이제 Acquaintance 데이터베이스에 동일한 (member, recommendedMember) 구성의 행은 무조건 하나만 존재해야 합니다.

### 2️⃣ 프로필 추천 로직 수정

주어진 Member에게 쌓인 RECOMMENDED 눈길 갯수를 조회하여, 하루 제한 횟수를 초과하였는지 확인하는 메서드를 구현했습니다.

```java
private boolean checkLimitExcess(Member member) {
    Long count = nungilRepository.countByMemberAndStatus(member, NungilStatus.RECOMMENDED);
    return RECOMMENDATION_LIMIT <= count;
}
```

더불어 기존의 '인연 프로필 뽑기' 메서드를 리팩토링 했습니다.

```java
@Transactional
public NungilResponse recommendMember(Member member, ProfileRecommendRequest request){

    // 1. 하루 제한 횟수를 초과한 경우, 예외를 발생시킨다.
    if (checkLimitExcess(member)) {
        throw new GeneralException(NungilErrorResult.LIMIT_EXCEEDED);
    }

    // 2. 회원 한 명을 추천받는다.
    Member recommendedMember = getRecommendedMember(member, request);
    if (recommendedMember == null) return null;

    // 3. 추천 받은 회원에 대한 지인 관계를 생성하고 저장한다.
    Acquaintance newAcquaintance = getAcquaintance(member, recommendedMember);
    acquaintanceRepository.save(newAcquaintance);

    // 4. 추천 받은 회원에 대한 눈길을 생성하고 저장한다.
    Nungil newNungil = Nungil.create(member, recommendedMember, NungilStatus.RECOMMENDED);
    nungilRepository.save(newNungil);

    // 5. 추천 받은 회원 정보를 반환한다.
    return convertToNungilResponse(recommendedMember);
}
```

### 3️⃣ 눈길 목록 조회 데이터에 닉네임 추가

프론트의 요청에 따라 눈길 목록 조회 데이터에 "닉네임"을 추가했습니다.

```java
public class NungilSliceResponse {
    ...
    private String nickname;
    ...
}
```

## 😡 Trouble Shooting

### 1️⃣ 인스턴스 생성 메서드 추가 및 다른 방식으로의 생성 제한

앞선 "Acquaintance 클래스에 status 필드 추가"와 "NungilSliceResponse 클래스에 nickname 필드 추가" 중 어려움이 발생했습니다.

필드가 추가됨에 따라, 각 클래스에 대한 인스턴스를 생성하는 코드에서 추가된 필드도 포함시켜야 했습니다.

하지만 기존 코드는 `@Builder`를 사용하여 각각의 클래스에 대한 인스턴스를 생성했기 때문에, 어느 위치에서 해당 클래스를 생성하는지 추적하기 어려웠습니다.

```java
List<NungilSliceResponse> nungilResponses = nungilSlice.getContent().stream()
        .map(nungil -> NungilSliceResponse.builder()
                .nungilId(nungil.getId())
                .animalFace(nungil.getReceiver().getAnimalFace().getTitle())
                .companyName(nungil.getReceiver().getCompany().getCompanyName())
                .job(nungil.getReceiver().getJob())
                .description(nungil.getReceiver().getDescription())
                .createdAt(nungil.getCreatedAt())
                .expiredAt(nungil.getExpiredAt())
                .build())
        .collect(Collectors.toList());
```

때문에 각 클래스에 대한 `@Builder`와 `@AllArgsConstructor`를 지우고, "정적 팩토리 메서드"를 생성하도록 했습니다.

```java
public static NungilSliceResponse create(Nungil nungil, Member member) {
    NungilSliceResponse response = new NungilSliceResponse();
    AnimalFace animalFace = member.getAnimalFace();
    Company company = member.getCompany();

    response.nungilId = nungil.getId();
    response.createdAt = nungil.getCreatedAt();
    response.expiredAt = nungil.getExpiredAt();

    response.animalFace = (animalFace != null) ? animalFace.getTitle() : null;
    response.companyName = (company != null) ? company.getCompanyName() : null;
    response.job = member.getJob();
    response.description = member.getDescription();
    response.nickname = member.getNickname();

    return response;
}
```

만약 필드가 더 추가된다면, 해당 메서드를 사용하는 곳으로 바로 추적할 수 있을 것입니다.

### 2️⃣ 데이터베이스 쿼리 최적화

앞서 말했듯이, 매 추천마다 동일한 구성을 가진 Acquaintance 데이터가 계속 쌓이는 것을 수정했습니다.

추가적으로 매 시각마다 데이터를 삭제하는 메서드에서 과도한 쿼리가 발생한다는 것을 알게 되었습니다.
기존 코드는 SELECT 쿼리 1번 + 데이터 갯수만큼 DELETE 쿼리 N번 발생하였습니다.

```java
@Transactional
public void deleteExpiredNungils() {
    LocalDateTime now = LocalDateTime.now();
    List<Nungil> expiredNungils = nungilRepository.findByExpiredAtBefore(now);
    for (Nungil nungil : expiredNungils) {
        nungilRepository.delete(nungil);
    }
}
```

JPQL을 사용하여 이를 DELETE 쿼리 1번 발생하도록 수정하였습니다.

```java
@Transactional
public void deleteExpiredNungils() {
    LocalDateTime now = LocalDateTime.now();
    nungilRepository.deleteAllByExpiredAtBefore(now);
}
```

```java
@Modifying
@Query("delete from Nungil n where n.expiredAt <= :dateTime")
void deleteAllByExpiredAtBefore(@Param("dateTime") LocalDateTime dateTime);
```
