### PR TITLE
[fix] 채팅 연결 실패 문제

### DIFF
--- a/src/main/java/com/iglooclub/nungil/config/SecurityConfig.java
+++ b/src/main/java/com/iglooclub/nungil/config/SecurityConfig.java
@@ -55,6 +55,7 @@ public class SecurityConfig {
                 // 인증, 인가 설정
                 .authorizeRequests()
                 .antMatchers("/api/auth/**").permitAll()
+                .antMatchers("/stomp", "/stomp/**").permitAll()
                 .anyRequest().authenticated()
                 .and()
 

--- a/src/main/java/com/iglooclub/nungil/config/jwt/ChatPreHandler.java
+++ b/src/main/java/com/iglooclub/nungil/config/jwt/ChatPreHandler.java
@@ -11,13 +11,13 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
+import static com.iglooclub.nungil.util.TokenUtil.*;
+
 @RequiredArgsConstructor
 @Component
 public class ChatPreHandler implements ChannelInterceptor {
 
     private final TokenProvider tokenProvider;
-    private final static String HEADER_AUTHORIZATION = "Authorization";
-    private final static String TOKEN_PREFIX = "Bearer ";
 
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
@@ -40,12 +40,5 @@ public class ChatPreHandler implements ChannelInterceptor {
         }
 
         return message;
-    }
-
-    private String getAccessToken(String authorizationHeader) {
-        if (authorizationHeader != null && authorizationHeader.startsWith(TOKEN_PREFIX)) {
-            return authorizationHeader.substring(TOKEN_PREFIX.length());
-        }
-        return null;
     }
 }

--- a/src/main/java/com/iglooclub/nungil/config/jwt/ChatPreHandler.java
+++ b/src/main/java/com/iglooclub/nungil/config/jwt/ChatPreHandler.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageDeliveryException;
+import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.security.core.Authentication;
@@ -22,17 +23,20 @@ public class ChatPreHandler implements ChannelInterceptor {
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
         StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(message);
 
-        // 요청 헤더의 Authorization 키의 값 조회
-        String authorizationHeader = String.valueOf(headerAccessor.getNativeHeader(HEADER_AUTHORIZATION));
-        // 가져온 값에서 접두사 제거
-        String token = getAccessToken(authorizationHeader);
-        // 가져온 토큰이 유효한지 확인하고, 유효한 때는 인증 정보 설정
-        if (tokenProvider.validateToken(token)) {
-            Authentication authentication = tokenProvider.getAuthentication(token);
-            SecurityContextHolder.getContext().setAuthentication(authentication);
-        } else {
-            // ChatErrorHandler 클래스에서 처리하는 예외와 에러 메시지가 "UNAUTHORIZED"로 동일해야 한다.
-            throw new MessageDeliveryException("UNAUTHORIZED");
+        if (StompCommand.CONNECT == headerAccessor.getCommand()) {
+            // 요청 헤더의 Authorization 키의 값 조회
+            String authorizationHeader = String.valueOf(headerAccessor.getFirstNativeHeader(HEADER_AUTHORIZATION));
+
+            // 가져온 값에서 접두사 제거
+            String token = getAccessToken(authorizationHeader);
+            // 가져온 토큰이 유효한지 확인하고, 유효한 때는 인증 정보 설정
+            if (tokenProvider.validateToken(token)) {
+                Authentication authentication = tokenProvider.getAuthentication(token);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            } else {
+                // ChatErrorHandler 클래스에서 처리하는 예외와 에러 메시지가 "UNAUTHORIZED"로 동일해야 한다.
+                throw new MessageDeliveryException("UNAUTHORIZED");
+            }
         }
 
         return message;

--- a/src/main/java/com/iglooclub/nungil/config/jwt/TokenAuthenticationFilter.java
+++ b/src/main/java/com/iglooclub/nungil/config/jwt/TokenAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package com.iglooclub.nungil.config.jwt;
 
+import com.iglooclub.nungil.util.TokenUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -11,12 +12,12 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
+import static com.iglooclub.nungil.util.TokenUtil.HEADER_AUTHORIZATION;
+import static com.iglooclub.nungil.util.TokenUtil.getAccessToken;
+
 @RequiredArgsConstructor
 public class TokenAuthenticationFilter extends OncePerRequestFilter {
     private final TokenProvider tokenProvider;
-    private final static String HEADER_AUTHORIZATION = "Authorization";
-    private final static String TOKEN_PREFIX = "Bearer ";
-
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
@@ -34,10 +35,4 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
     }
 
-    private String getAccessToken(String authorizationHeader) {
-        if (authorizationHeader != null && authorizationHeader.startsWith(TOKEN_PREFIX)) {
-            return authorizationHeader.substring(TOKEN_PREFIX.length());
-        }
-        return null;
-    }
 }

--- a/src/main/java/com/iglooclub/nungil/util/TokenUtil.java
+++ b/src/main/java/com/iglooclub/nungil/util/TokenUtil.java
@@ -1,0 +1,15 @@
+package com.iglooclub.nungil.util;
+
+public class TokenUtil {
+
+    public final static String HEADER_AUTHORIZATION = "Authorization";
+
+    public final static String TOKEN_PREFIX = "Bearer ";
+
+    public static String getAccessToken(String authorizationHeader) {
+        if (authorizationHeader != null && authorizationHeader.startsWith(TOKEN_PREFIX)) {
+            return authorizationHeader.substring(TOKEN_PREFIX.length());
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## 🔥 Related Issues

- close #44

## 💜 작업 내용

- [x] 웹 소켓 연결 엔드포인트를 SecurityConfig에서 허용
- [x] 웹 소켓에서 인증을 "연결" 시에만 수행
- [x] 메시지 전송할 때, 인증 정보에서 회원 정보 추출하는 방식 변경

## ✅ PR Point

### 1️⃣ 웹 소켓 연결 방식 수정

- 웹 소켓 연결은 HTTP/HTTPS를 통해 수행되기 때문에, Spring Security에서 토큰 부재로 막히는 문제 발생
- SecurityConfig에서 웹 소켓 연결 엔드포인트(`/stomp`)와 그 하위 경로로의 접근을 허용하도록 수정

```java
                // 인증, 인가 설정
                .authorizeRequests()
                .antMatchers("/api/auth/**").permitAll()
                .antMatchers("/stomp", "/stomp/**").permitAll()
                .anyRequest().authenticated()
                .and()
```

- 웹 소켓 연결에 대한 인증은 인터셉터(interceptor)에서 수행

- 기존에는 모든 요청에 대하여 인증을 수행했지만, '구독(subscribe)'과 같은 요청에서 토큰 부재로 연결이 해제되는 문제 발생
- 따라서 오직 '연결(connect)'에 대해서만 인증 수행

```java
@RequiredArgsConstructor
@Component
public class ChatPreHandler implements ChannelInterceptor {

    private final TokenProvider tokenProvider;

    @Override
    public Message<?> preSend(Message<?> message, MessageChannel channel) {
        StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(message);

        if (StompCommand.CONNECT == headerAccessor.getCommand()) {
            // 요청 헤더의 Authorization 키의 값 조회
            String authorizationHeader = String.valueOf(headerAccessor.getFirstNativeHeader(HEADER_AUTHORIZATION));

            // 가져온 값에서 접두사 제거
            String token = getAccessToken(authorizationHeader);
            // 가져온 토큰이 유효한지 확인하고, 유효한 때는 인증 정보 설정
            if (tokenProvider.validateToken(token)) {
                Authentication authentication = tokenProvider.getAuthentication(token);
                SecurityContextHolder.getContext().setAuthentication(authentication);
            } else {
                // ChatErrorHandler 클래스에서 처리하는 예외와 에러 메시지가 "UNAUTHORIZED"로 동일해야 한다.
                throw new MessageDeliveryException("UNAUTHORIZED");
            }
        }

        return message;
    }
}
```

### 2️⃣ 메시지 전송 시 회원 정보 추출 방식 변경

- 기존에는 Principal을 통해 회원 정보 추출
- 현재는 헤더에 포함된 인증 정보를 통해 Principal을 조회하고, 회원 정보 추출하도록 변경

```java
@MessageMapping("/send")
public void send(@Payload ChatDTO chatDTO, @Header(HEADER_AUTHORIZATION) String authorizationHeader) {
    String accessToken = getAccessToken(authorizationHeader);
    Authentication authentication = tokenProvider.getAuthentication(accessToken);
    Member member = getMember(authentication);

    ChatDTO mappedChat = chatMessageService.save(chatDTO, member);

    messagingTemplate.convertAndSend("/topic/" + chatDTO.getChatRoomId(), mappedChat);
}
```

## ☀ 스크린샷 / GIF / 화면 녹화

<img src = "https://github.com/Igloo-Club/Igloo-Club-BE/assets/50361496/78491e65-c351-4e65-9112-d8bf523d4d94" width="700" />

## 📚 Reference

https://www.daddyprogrammer.org/post/5072/spring-websocket-chatting-server-spring-security-jwt/
