### PR TITLE
[fix] checkLimitExcess

### DIFF
--- a/src/main/java/com/iglooclub/nungil/domain/Acquaintance.java
+++ b/src/main/java/com/iglooclub/nungil/domain/Acquaintance.java
@@ -1,6 +1,6 @@
 package com.iglooclub.nungil.domain;
 
-import com.iglooclub.nungil.domain.enums.AcquaintanceStatus;
+import com.iglooclub.nungil.domain.enums.NungilStatus;
 import lombok.*;
 
 import javax.persistence.*;
@@ -22,10 +22,10 @@ public class Acquaintance {
     private Member acquaintanceMember;
 
     @Enumerated(EnumType.STRING)
-    private AcquaintanceStatus status;
+    private NungilStatus status;
 
     // == 생성 메서드 == //
-    public static Acquaintance create(Member member, Member acquaintanceMember, AcquaintanceStatus status) {
+    public static Acquaintance create(Member member, Member acquaintanceMember, NungilStatus status) {
         Acquaintance acquaintance = new Acquaintance();
 
         acquaintance.member = member;
@@ -37,7 +37,7 @@ public class Acquaintance {
 
     // == 비즈니스 로직 == //
 
-    public void update(AcquaintanceStatus status) {
+    public void update(NungilStatus status) {
         this.status = status;
     }
 }

--- a/src/main/java/com/iglooclub/nungil/domain/enums/AcquaintanceStatus.java
+++ b/src/main/java/com/iglooclub/nungil/domain/enums/AcquaintanceStatus.java
@@ -1,8 +1,0 @@
-package com.iglooclub.nungil.domain.enums;
-
-public enum AcquaintanceStatus {
-    RECEIVED,
-    SENT,
-    MATCHED,
-    RECOMMENDED,
-}

--- a/src/main/java/com/iglooclub/nungil/repository/AcquaintanceRepository.java
+++ b/src/main/java/com/iglooclub/nungil/repository/AcquaintanceRepository.java
@@ -2,7 +2,6 @@ package com.iglooclub.nungil.repository;
 
 import com.iglooclub.nungil.domain.Acquaintance;
 import com.iglooclub.nungil.domain.Member;
-import com.iglooclub.nungil.domain.enums.AcquaintanceStatus;
 import com.iglooclub.nungil.domain.enums.NungilStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -19,5 +18,7 @@ public interface AcquaintanceRepository extends JpaRepository<Acquaintance, Long
 
     @Modifying
     @Query("delete from Acquaintance a where a.status = :status")
-    void deleteAllByStatus(@Param("status") AcquaintanceStatus status);
+    void deleteAllByStatus(@Param("status") NungilStatus status);
+
+    Long countByMemberAndStatus(Member member, NungilStatus status);
 }

--- a/src/main/java/com/iglooclub/nungil/repository/NungilRepository.java
+++ b/src/main/java/com/iglooclub/nungil/repository/NungilRepository.java
@@ -27,6 +27,4 @@ public interface NungilRepository extends JpaRepository<Nungil, Long> {
     @Modifying
     @Query("delete from Nungil n where n.expiredAt <= :dateTime")
     void deleteAllByExpiredAtBefore(@Param("dateTime") LocalDateTime dateTime);
-
-    Long countByMemberAndStatus(Member member, NungilStatus status);
 }

--- a/src/main/java/com/iglooclub/nungil/service/NungilService.java
+++ b/src/main/java/com/iglooclub/nungil/service/NungilService.java
@@ -93,7 +93,7 @@ public class NungilService {
      * @return 초과한 경우 true, 제한 횟수가 남은 경우 false
      */
     private boolean checkLimitExcess(Member member) {
-        Long count = nungilRepository.countByMemberAndStatus(member, NungilStatus.RECOMMENDED);
+        Long count = acquaintanceRepository.countByMemberAndStatus(member, NungilStatus.RECOMMENDED);
         return RECOMMENDATION_LIMIT <= count;
     }
 
@@ -200,11 +200,11 @@ public class NungilService {
 
         // 서로에 대한 Acquaintance 객체 생성 및 저장
         Acquaintance acquaintanceFromMember = getAcquaintance(member, sender);
-        acquaintanceFromMember.update(AcquaintanceStatus.MATCHED);
+        acquaintanceFromMember.update(NungilStatus.MATCHED);
         acquaintanceRepository.save(acquaintanceFromMember);
 
         Acquaintance acquaintanceFromSender = getAcquaintance(sender, member);
-        acquaintanceFromSender.update(AcquaintanceStatus.MATCHED);
+        acquaintanceFromSender.update(NungilStatus.MATCHED);
         acquaintanceRepository.save(acquaintanceFromSender);
 
         String marker = null;
@@ -266,7 +266,7 @@ public class NungilService {
     @Transactional
     public void deleteRecommendedNungils() {
         nungilRepository.deleteAllByStatus(NungilStatus.RECOMMENDED);
-        acquaintanceRepository.deleteAllByStatus(AcquaintanceStatus.RECOMMENDED);
+        acquaintanceRepository.deleteAllByStatus(NungilStatus.RECOMMENDED);
     }
 
     private Member getMember(Principal principal) {
@@ -381,6 +381,6 @@ public class NungilService {
      */
     private Acquaintance getAcquaintance(Member member, Member acquaintanceMember) {
         return acquaintanceRepository.findByMemberAndAcquaintanceMember(member, acquaintanceMember)
-                .orElse(Acquaintance.create(member, acquaintanceMember, AcquaintanceStatus.RECOMMENDED));
+                .orElse(Acquaintance.create(member, acquaintanceMember, NungilStatus.RECOMMENDED));
     }
 }


### PR DESCRIPTION
## 🔥 Related Issues

- close #49 

## 💜 작업 내용

- [x] AcquaintanceStatus -> NungilStatus
- [x] countByMemberAndStatus를 NungilRepostiory에서 AcquaintanceRepository로 이동

## ✅ PR Point

Nungil 테이블 상에 RECOMMENDED 상태의 눈길을 조회 시 MATCH 상태로 빠지게 된 경우 CheckLimitExcess에 걸리지 않는 문제 발생, 따라서 이런 문제를 해결하기 위해 countByMemberAndStatus JPA를 AcquaintanceRepository로 이동해 Acquaintance 테이블 상에 처리해주도록 변경

AcquaintanceStatus와 NungilStatus는 구조적으로 동일하기 때문에 AcquaintanceStatus를 제거하고 NungilStatus로 대체


