### PR TITLE
[fix] register 프로세스 마커 등록되게끔 수정

### DIFF
--- a/src/main/java/com/iglooclub/nungil/controller/MemberController.java
+++ b/src/main/java/com/iglooclub/nungil/controller/MemberController.java
@@ -1,7 +1,7 @@
 package com.iglooclub.nungil.controller;
 
 import com.iglooclub.nungil.domain.Member;
-import com.iglooclub.nungil.domain.enums.Marker;
+import com.iglooclub.nungil.domain.enums.Location;
 import com.iglooclub.nungil.dto.*;
 import com.iglooclub.nungil.service.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -75,8 +75,8 @@ public class MemberController {
     }
 
     @GetMapping("/api/markers")
-    public List<MarkerDTO> getAllMarkers(){
-        return memberService.getAllMarkers();
+    public List<MarkerDTO> getAllMarkers(@RequestParam Location location){
+        return memberService.getAllMarkers(location);
     }
 
     private Member getMember(Principal principal) {

--- a/src/main/java/com/iglooclub/nungil/controller/MemberController.java
+++ b/src/main/java/com/iglooclub/nungil/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.iglooclub.nungil.controller;
 
 import com.iglooclub.nungil.domain.Member;
+import com.iglooclub.nungil.domain.enums.Marker;
 import com.iglooclub.nungil.dto.*;
 import com.iglooclub.nungil.service.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -9,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -70,6 +72,11 @@ public class MemberController {
         Member member = getMember(principal);
         memberService.updateLocation(request,member);
         return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @GetMapping("/api/markers")
+    public List<MarkerDTO> getAllMarkers(){
+        return memberService.getAllMarkers();
     }
 
     private Member getMember(Principal principal) {

--- a/src/main/java/com/iglooclub/nungil/domain/Member.java
+++ b/src/main/java/com/iglooclub/nungil/domain/Member.java
@@ -281,7 +281,7 @@ public class Member {
         this.company = company;
     }
 
-    public void updateSchedule(Location location, List<Yoil> yoilList, List<AvailableTime> availableTimeList) {
+    public void updateSchedule(Location location, List<Yoil> yoilList, List<AvailableTime> availableTimeList, List<Marker> markerList) {
         List<AvailableTimeAllocation> newAvailableTimeAllocationList = availableTimeList.stream()
                 .map(v -> AvailableTimeAllocation.builder().availableTime(v).member(this).build())
                 .collect(Collectors.toList());
@@ -293,9 +293,10 @@ public class Member {
         this.availableTimeAllocationList.addAll(newAvailableTimeAllocationList);
 
         //===== 사용자가 마커 선택하는 API 추가 시 삭제 =====//
-        List<Marker> markerList = Arrays.stream(Marker.values())
-                .filter(marker -> marker.getLocation() == location)
-                .collect(Collectors.toList());
+//        List<Marker> markerList = Arrays.stream(Marker.values())
+//                .filter(marker -> marker.getLocation() == location)
+//                .collect(Collectors.toList());
+
         List<MarkerAllocation> newMarkerAllocationList = markerList.stream()
                 .map(v -> MarkerAllocation.builder().marker(v).member(this).build())
                 .collect(Collectors.toList());

--- a/src/main/java/com/iglooclub/nungil/dto/MarkerDTO.java
+++ b/src/main/java/com/iglooclub/nungil/dto/MarkerDTO.java
@@ -1,0 +1,27 @@
+package com.iglooclub.nungil.dto;
+
+import com.iglooclub.nungil.domain.enums.Marker;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MarkerDTO {
+    private String title;
+
+    private Double latitude;
+
+    private Double longitude;
+
+    public static MarkerDTO create(Marker marker){
+        MarkerDTO response = new MarkerDTO();
+        response.title = marker.getTitle();
+        response.latitude = marker.getLatitude();
+        response.longitude = marker.getLongitude();
+        return response;
+    }
+}

--- a/src/main/java/com/iglooclub/nungil/dto/ScheduleUpdateRequest.java
+++ b/src/main/java/com/iglooclub/nungil/dto/ScheduleUpdateRequest.java
@@ -2,6 +2,7 @@ package com.iglooclub.nungil.dto;
 
 import com.iglooclub.nungil.domain.enums.AvailableTime;
 import com.iglooclub.nungil.domain.enums.Location;
+import com.iglooclub.nungil.domain.enums.Marker;
 import com.iglooclub.nungil.domain.enums.Yoil;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -19,4 +20,6 @@ public class ScheduleUpdateRequest {
     private List<AvailableTime> availableTimeList;
 
     private List<Yoil> yoilList;
+
+    private List<Marker> markerList;
 }

--- a/src/main/java/com/iglooclub/nungil/repository/AcquaintanceRepository.java
+++ b/src/main/java/com/iglooclub/nungil/repository/AcquaintanceRepository.java
@@ -24,6 +24,6 @@ public interface AcquaintanceRepository extends JpaRepository<Acquaintance, Long
     Long countByMemberAndStatus(Member member, NungilStatus status);
 
     @Modifying
-    @Query("delete from Acquaintance a where a.expiredAt <= :dateTime")
+    @Query("delete from Acquaintance a where a.expiredAt <= :now")
     void deleteAllByExpiredAtBefore(LocalDateTime now);
 }

--- a/src/main/java/com/iglooclub/nungil/service/MemberService.java
+++ b/src/main/java/com/iglooclub/nungil/service/MemberService.java
@@ -14,10 +14,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
@@ -210,6 +208,17 @@ public class MemberService {
     @Transactional
     public void updateLocation(LocationRequest locationRequest, Member member){
         member.updateLocation(locationRequest.getLocation());
+    }
+
+    /**
+     * 모든 마커 정보를 조회하는 메서드이다.
+     *
+     */
+    public List<MarkerDTO> getAllMarkers() {
+        List<MarkerDTO> markerList = Arrays.asList(Marker.values()).stream()
+                .map(marker -> MarkerDTO.create(marker))
+                .collect(Collectors.toList());
+        return markerList;
     }
 
 }

--- a/src/main/java/com/iglooclub/nungil/service/MemberService.java
+++ b/src/main/java/com/iglooclub/nungil/service/MemberService.java
@@ -113,7 +113,7 @@ public class MemberService {
         List<Yoil> sortedYoilList = request.getYoilList();
         Collections.sort(sortedYoilList);
 
-        member.updateSchedule(request.getLocation(), sortedYoilList, request.getAvailableTimeList());
+        member.updateSchedule(request.getLocation(), sortedYoilList, request.getAvailableTimeList(), request.getMarkerList());
     }
 
     /**

--- a/src/main/java/com/iglooclub/nungil/service/MemberService.java
+++ b/src/main/java/com/iglooclub/nungil/service/MemberService.java
@@ -212,10 +212,11 @@ public class MemberService {
 
     /**
      * 모든 마커 정보를 조회하는 메서드이다.
-     *
+     * @param location 반환 마커 소재지
      */
-    public List<MarkerDTO> getAllMarkers() {
+    public List<MarkerDTO> getAllMarkers(Location location) {
         List<MarkerDTO> markerList = Arrays.asList(Marker.values()).stream()
+                .filter(marker -> marker.getLocation() == location)
                 .map(marker -> MarkerDTO.create(marker))
                 .collect(Collectors.toList());
         return markerList;


### PR DESCRIPTION
## 🔥 Related Issues

- close #55 

## 💜 작업 내용

- [x] 지역별 마커 전체 조회 api 추가
- [x] 가능한 지역,요일,시간대 추가/수정 api request로 마커를 받고 마커 등록하게끔 수정

## ✅ PR Point

- getAllMakres 메서드를 추가해 지역별 마커를 반환해줄 수 있게끔 하였습니다.
MemberService/getAllMarkers
```
public List<MarkerDTO> getAllMarkers(Location location) {
        List<MarkerDTO> markerList = Arrays.asList(Marker.values()).stream()
                .filter(marker -> marker.getLocation() == location)
                .map(marker -> MarkerDTO.create(marker))
                .collect(Collectors.toList());
        return markerList;
    }
```
- Member/updateSchedule 의 기존 마커 전분를 넣어주는 로직을 아래와 같이 markerList를 param으로 받아와 설정가능하게끔 수정했습니다.
```
,,,
        //===== 사용자가 마커 선택하는 API 추가 시 삭제 =====//
//        List<Marker> markerList = Arrays.stream(Marker.values())
//                .filter(marker -> marker.getLocation() == location)
//                .collect(Collectors.toList());

        List<MarkerAllocation> newMarkerAllocationList = markerList.stream()
                .map(v -> MarkerAllocation.builder().marker(v).member(this).build())
                .collect(Collectors.toList());
,,,
```

## ☀ 스크린샷 / GIF / 화면 녹화

![image](https://github.com/Igloo-Club/Igloo-Club-BE/assets/106146847/9d28f2a6-d9a9-403f-9856-abb7e0ffebf4)
![image](https://github.com/Igloo-Club/Igloo-Club-BE/assets/106146847/53917b4f-0cf0-4dfb-a23b-76fb7fa25f92)
