### PR TITLE
fix : 매칭된 눈길 상세 조회 예외 처리 추가

### DIFF
--- a/src/main/java/com/iglooclub/nungil/exception/ChatRoomErrorResult.java
+++ b/src/main/java/com/iglooclub/nungil/exception/ChatRoomErrorResult.java
@@ -7,7 +7,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum ChatRoomErrorResult implements ErrorResult {
-
+    CHAT_ROOM_MORE_THAN_ONE(HttpStatus.CONFLICT, "More than one chat room"),
     CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "Failed to find the chat room"),
     NOT_MEMBER(HttpStatus.FORBIDDEN, "Only available for the member of the chat room"),
     ;

--- a/src/main/java/com/iglooclub/nungil/repository/ChatRoomRepository.java
+++ b/src/main/java/com/iglooclub/nungil/repository/ChatRoomRepository.java
@@ -19,5 +19,5 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long>, Pagin
     Slice<ChatRoom> findBySenderOrReceiver(Member sender, Member receiver, Pageable pageable);
 
     @Query("select c from ChatRoom c where (c.sender = :member1 and c.receiver = :member2) or (c.sender = :member2 and c.receiver = :member1)")
-    Optional<ChatRoom> findByMembers(@Param("member1") Member member1, @Param("member2") Member member2);
+    List<ChatRoom> findByMembers(@Param("member1") Member member1, @Param("member2") Member member2);
 }

--- a/src/main/java/com/iglooclub/nungil/service/NungilService.java
+++ b/src/main/java/com/iglooclub/nungil/service/NungilService.java
@@ -3,6 +3,7 @@ package com.iglooclub.nungil.service;
 import com.iglooclub.nungil.domain.*;
 import com.iglooclub.nungil.domain.enums.*;
 import com.iglooclub.nungil.dto.*;
+import com.iglooclub.nungil.exception.ChatRoomErrorResult;
 import com.iglooclub.nungil.exception.GeneralException;
 import com.iglooclub.nungil.exception.MemberErrorResult;
 import com.iglooclub.nungil.exception.NungilErrorResult;
@@ -240,8 +241,6 @@ public class NungilService {
 
     /**
      * 공통 매칭 정보를 조회하는 api입니다
-     *
-     *
      * @param nungilId 눈길 id
      * @response nungilMatchResponse 눈길 매칭 정보
      */
@@ -255,10 +254,16 @@ public class NungilService {
             throw new GeneralException(MemberErrorResult.NOT_OWNER);
         }
 
+        List<ChatRoom> chatRooms = chatRoomRepository.findByMembers(nungil.getMember(), nungil.getReceiver());
+
+        // chat room 2개 이상일 경우 예외 처리
+        if (chatRooms.size() > 1) {
+            throw new GeneralException(ChatRoomErrorResult.CHAT_ROOM_MORE_THAN_ONE);
+        }
+
         // 두 사용자가 속한 채팅방이 존재하지 않는 경우 null을 반환한다.
-        Long chatRoomId = chatRoomRepository.findByMembers(nungil.getMember(), nungil.getReceiver())
-                .map(ChatRoom::getId)
-                .orElse(null);
+        Long chatRoomId = chatRooms.isEmpty() ? null : chatRooms.get(0).getId();
+
 
         return NungilMatchResponse.create(nungil, chatRoomId);
     }


### PR DESCRIPTION
## 🔥 Related Issues

- close #58 

## 💜 작업 내용

- [x] 예외 처리 로직 추가

## ✅ PR Point

-  채팅방이 2개 이상인 경우 "매칭된 눈길 상세 조회" api에서 에러 발생
```
code
: 
"UNKNOWN_EXCEPTION"
message
: 
"query did not return a unique result: 3; nested exception is javax.persistence.NonUniqueResultException: query did not return a unique result: 3"
```
- 해당 예외는 동일한 2 사용자 사이의 채팅방이 2개 이상 있는 경우 발생
- chatRoomRepository 의 `findByMembers` 메서드를 Optional에서 List로 수정
```
@Query("select c from ChatRoom c where (c.sender = :member1 and c.receiver = :member2) or (c.sender = :member2 and c.receiver = :member1)")
    List<ChatRoom> findByMembers(@Param("member1") Member member1, @Param("member2") Member member2);
```
-  `getMatchedNungil`에서 findByMembers를 통해 반환된 ChatRoom이 2개 이상일 시 예외 발생하게끔 처리
```
        List<ChatRoom> chatRooms = chatRoomRepository.findByMembers(nungil.getMember(), nungil.getReceiver());

        // chat room 2개 이상일 경우 예외 처리
        if (chatRooms.size() > 1) {
            throw new GeneralException(ChatRoomErrorResult.CHAT_ROOM_MORE_THAN_ONE);
        }

        // 두 사용자가 속한 채팅방이 존재하지 않는 경우 null을 반환한다.
        Long chatRoomId = chatRooms.isEmpty() ? null : chatRooms.get(0).getId();

```

