### PR TITLE
fix : check draws with draw count

### DIFF
--- a/src/main/java/com/iglooclub/nungil/domain/Member.java
+++ b/src/main/java/com/iglooclub/nungil/domain/Member.java
@@ -11,7 +11,6 @@ import lombok.Getter;
 import javax.persistence.*;
 import java.time.LocalDate;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -97,6 +96,10 @@ public class Member {
 
     private Integer preferredAgeEnd;
 
+    // 인연 프로필 뽑기 횟수
+    @Builder.Default
+    private Long drawCount = 0L;
+
     @Builder.Default
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<HobbyAllocation> hobbyAllocationList = new ArrayList<>();
@@ -138,6 +141,7 @@ public class Member {
         this.personalityDepictionAllocationList = new ArrayList<>();
         this.markerAllocationList = new ArrayList<>();
         this.yoilList = new ArrayList<>();
+        this.drawCount = 0L;
     }
 
     // == 비즈니스 로직 == //
@@ -259,13 +263,6 @@ public class Member {
         this.markerAllocationList.add(markerAllocation);
     }
 
-    public void addAvailableTime(AvailableTime availableTime) {
-        AvailableTimeAllocation availableTimeAllocation = AvailableTimeAllocation.builder()
-                .availableTime(availableTime)
-                .member(this)
-                .build();
-        this.availableTimeAllocationList.add(availableTimeAllocation);
-    }
 
     public void addHobby(Hobby hobby) {
         HobbyAllocation hobbyAllocation = HobbyAllocation.builder()
@@ -291,10 +288,6 @@ public class Member {
         this.availableTimeAllocationList.clear();
         this.availableTimeAllocationList.addAll(newAvailableTimeAllocationList);
 
-        //===== 사용자가 마커 선택하는 API 추가 시 삭제 =====//
-//        List<Marker> markerList = Arrays.stream(Marker.values())
-//                .filter(marker -> marker.getLocation() == location)
-//                .collect(Collectors.toList());
 
         List<MarkerAllocation> newMarkerAllocationList = markerList.stream()
                 .map(v -> MarkerAllocation.builder().marker(v).member(this).build())
@@ -302,7 +295,6 @@ public class Member {
 
         this.markerAllocationList.clear();
         this.markerAllocationList.addAll(newMarkerAllocationList);
-        //=============================================//
     }
 
 
@@ -311,6 +303,8 @@ public class Member {
     }
 
     public void updateLocation(Location location) {this.location = location;}
+
+    public void plusDrawCount() {this.drawCount += 1L;}
 
 
     // List를 String으로 변환하는 메서드

--- a/src/main/java/com/iglooclub/nungil/repository/MemberRepository.java
+++ b/src/main/java/com/iglooclub/nungil/repository/MemberRepository.java
@@ -3,6 +3,8 @@ package com.iglooclub.nungil.repository;
 import com.iglooclub.nungil.domain.Member;
 import com.iglooclub.nungil.domain.OauthInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
@@ -12,4 +14,8 @@ public interface MemberRepository extends JpaRepository<Member, Long>, MemberRep
     Optional<Member> findByEmail(String email);
 
     Optional<Member> findByPhoneNumber(String phoneNumber);
+
+    @Modifying
+    @Query("update Member a set a.drawCount =0 where a.drawCount > 0")
+    void initDrawCount();
 }

--- a/src/main/java/com/iglooclub/nungil/service/MemberService.java
+++ b/src/main/java/com/iglooclub/nungil/service/MemberService.java
@@ -10,6 +10,7 @@ import com.iglooclub.nungil.exception.MemberErrorResult;
 import com.iglooclub.nungil.repository.*;
 import com.iglooclub.nungil.util.*;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -199,6 +200,16 @@ public class MemberService {
         Boolean disableCompany = member.toggleDisableCompany();
 
         return DisableCompanyResponse.create(disableCompany);
+    }
+
+    /**
+     * 매일 오후 3시에 drawCount = 0으로 초기화
+     *
+     */
+    @Scheduled(cron = "0 0 15 * * *") // 매일 오후 3시에 실행
+    @Transactional
+    public void initMemberDrawCount() {
+        memberRepository.initDrawCount();
     }
 
     /**

--- a/src/main/java/com/iglooclub/nungil/service/NungilService.java
+++ b/src/main/java/com/iglooclub/nungil/service/NungilService.java
@@ -68,7 +68,10 @@ public class NungilService {
         Nungil newNungil = Nungil.create(member, recommendedMember, NungilStatus.RECOMMENDED);
         nungilRepository.save(newNungil);
 
-        // 5. 추천 받은 회원 정보를 반환한다.
+        // 5. 추천이 정상적으로 동작했을 시 drawCount를 1 증가 시킨다.
+        member.plusDrawCount();
+
+        // 6. 추천 받은 회원 정보를 반환한다.
         return convertToNungilResponse(recommendedMember);
     }
 
@@ -95,7 +98,7 @@ public class NungilService {
      * @return 초과한 경우 true, 제한 횟수가 남은 경우 false
      */
     private boolean checkLimitExcess(Member member) {
-        Long count = acquaintanceRepository.countByMemberAndStatus(member, NungilStatus.RECOMMENDED);
+        Long count = member.getDrawCount();
         return RECOMMENDATION_LIMIT <= count;
     }
 


### PR DESCRIPTION
## 🔥 Related Issues

- close #62 

## 💜 작업 내용

- [x]  member 엔티티에 새로운 drawCount 필드 생성
- [x]  checkLimitExcess 메서드 변경
- [x] drawCount 15시에 초기화

## ✅ PR Point

- member 엔티티에 새로운 drawCount 필드 생성
```
    // 인연 프로필 뽑기 횟수
    @Builder.Default
    private Long drawCount = 0L;
```
- checkLimitExcess 메서드 변경
- 기존의 acquaintace에서 recommended 개수로 비교하는 방식에서 member의 drawCount로 비교하는 방식으로 변경
```
    private boolean checkLimitExcess(Member member) {
        Long count = member.getDrawCount();
        return RECOMMENDATION_LIMIT <= count;
    }
```
- drawCount 15시에 초기화, jpql 사용
MemberService
```
    @Scheduled(cron = "0 0 15 * * *") // 매일 오후 3시에 실행
    @Transactional
    public void initMemberDrawCount() {
        memberRepository.initDrawCount();
    }
```
MemberRepository
```
    @Modifying
    @Query("update Member a set a.drawCount =0 where a.drawCount > 0")
    void initDrawCount();

```