### PR TITLE
[refactor] Allowed Origins를 환경에 따라 분리

### DIFF
--- a/src/main/java/com/iglooclub/nungil/NungilApplication.java
+++ b/src/main/java/com/iglooclub/nungil/NungilApplication.java
@@ -2,10 +2,12 @@ package com.iglooclub.nungil;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableScheduling
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class NungilApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/iglooclub/nungil/config/RedisConfig.java
+++ b/src/main/java/com/iglooclub/nungil/config/RedisConfig.java
@@ -1,6 +1,9 @@
 package com.iglooclub.nungil.config;
 
-import org.springframework.beans.factory.annotation.Value;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -9,21 +12,15 @@ import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactor
 import org.springframework.data.redis.core.RedisTemplate;
 
 @Configuration
+@RequiredArgsConstructor
 public class RedisConfig {
 
-    @Value("${spring.redis.host}")
-    private String host;
-
-    @Value("${spring.redis.port}")
-    private int port;
-
-    @Value("${spring.redis.password}")
-    private String password;
+    private final RedisConfigProperties properties;
 
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
-        RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration(host, port);
-        configuration.setPassword(password);
+        RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration(properties.getHost(), properties.getPort());
+        configuration.setPassword(properties.getPassword());
         return new LettuceConnectionFactory(configuration);
     }
 
@@ -32,5 +29,18 @@ public class RedisConfig {
         RedisTemplate<?, ?> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory());
         return redisTemplate;
+    }
+
+    @Getter
+    @ConfigurationProperties(prefix = "spring.redis")
+    @ConstructorBinding
+    @RequiredArgsConstructor
+    private static class RedisConfigProperties {
+
+        private final String host;
+
+        private final int port;
+
+        private final String password;
     }
 }

--- a/src/main/java/com/iglooclub/nungil/config/SecurityConfig.java
+++ b/src/main/java/com/iglooclub/nungil/config/SecurityConfig.java
@@ -4,8 +4,11 @@ import com.iglooclub.nungil.config.jwt.JwtAccessDeniedHandler;
 import com.iglooclub.nungil.config.jwt.JwtAuthenticationEntryPoint;
 import com.iglooclub.nungil.config.jwt.TokenAuthenticationFilter;
 import com.iglooclub.nungil.config.jwt.TokenProvider;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -24,6 +27,8 @@ import java.util.List;
 public class SecurityConfig {
 
     private final TokenProvider tokenProvider;
+
+    private final SecurityConfigProperties securityConfigProperties;
 
     /**
      * 스프링 시큐리티 기능 비활성화
@@ -80,7 +85,7 @@ public class SecurityConfig {
         CorsConfiguration config = new CorsConfiguration();
 
         config.setAllowedOrigins(
-                List.of("http://localhost:8080", "http://localhost:3000", "http://localhost:5173", "https://www.nungil.com")
+                securityConfigProperties.getAllowedOrigins()
         );
         config.setAllowedMethods(
                 List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
@@ -96,6 +101,15 @@ public class SecurityConfig {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", config);
         return source;
+    }
+
+    @Getter
+    @ConfigurationProperties(prefix = "security")
+    @ConstructorBinding
+    @RequiredArgsConstructor
+    private static class SecurityConfigProperties {
+
+        private final List<String> allowedOrigins;
     }
 }
 


### PR DESCRIPTION
## 🔥 Related Issues

- close #70 

## 💜 작업 내용

- [x] Allowed Origins를 환경에 따라 분리
- [x] Redis에 대한 환경 변수를 ConfigurationProperties로 바인드

## ✅ PR Point

### 1️⃣ Allowed Origins를 환경에 따라 분리

+ 개발 서버와 배포 서버를 분리함에 따라, CORS 설정을 다르게 할 필요 발생
+ 아래와 같이 SecurityConfig에 내부 클래스로 SecurityConfigProperties 클래스를 생성하고, `@ConfigurationProperties` 방식으로 allowed origins를 주입 받도록 함

```java
@Getter
@ConfigurationProperties(prefix = "security")
@ConstructorBinding
@RequiredArgsConstructor
private static class SecurityConfigProperties {

    private final List<String> allowedOrigins;
}
```

```java
@Bean
public CorsConfigurationSource corsConfigurationSource() {
    CorsConfiguration config = new CorsConfiguration();

    config.setAllowedOrigins(
            securityConfigProperties.getAllowedOrigins()
    );
    ...
}
```

+ 또한, `@ConfigurationPropertiesScan`을 통해 클래스가 `@ConfigurationProperties`를 통한 주입 대상으로 지정되게 하였다.

```java
@EnableScheduling
@SpringBootApplication
@ConfigurationPropertiesScan
public class NungilApplication {
    public static void main(String[] args) {
        SpringApplication.run(NungilApplication.class, args);
    }
}
```


### 2️⃣ Redis에 대한 환경 변수를 `@ConfigurationProperties`로 바인드

+ Spring에서는 여러 값을 바인딩하는 경우, `@Value` 대신 `@ConfigurationProperties` 방식을 권장
+ 이를 고려하여, Redis 설정에 사용하는 프로퍼티를 주입받는 RedisConfigProperties 생성

```java
@Getter
@ConfigurationProperties(prefix = "spring.redis")
@ConstructorBinding
@RequiredArgsConstructor
private static class RedisConfigProperties {

    private final String host;

    private final int port;

    private final String password;
}
```

## 😡 Trouble Shooting

### 1️⃣ `@ConfigurationProperties` : Setter v.s. 생성자

+ `@ConfigurationProperties`는 기본적으로 Setter를 사용하여 지정된 클래스에 값을 주입한다.
+ 하지만, Setter를 사용하는 것은 해당 객체가 불변 객체가 아니라 변경 가능하다는 점에서 위험이 존재한다.
+ 이에 따라, `@ConstructorBinding` 어노테이션을 사용하여 해당 클래스가 생성자 방식으로 값을 주입하도록 하였다.

```java
@Getter
@ConfigurationProperties(prefix = "spring.redis")    // @Value 대신 사용
@ConstructorBinding    // 생성자 방식으로 주입
@RequiredArgsConstructor    // 생성자
private static class RedisConfigProperties {

    private final String host;

    private final int port;

    private final String password;
}
```

### 2️⃣ `@Component`와 `@ConstructorBinding`

+ 본래는 주입 받는 값을 내부 클래스로 관리하지 않고, 해당 클래스 자체에서 필드로 관리할 예정이었다.

```java
@Configuration
@ConfigurationProperties(prefix = "security")
@ConstructorBinding
@RequiredArgsConstructor
public class SecurityConfig {

    private final List<String> allowedOrigins;
    ...
}
```

+ 하지만, 생성자 방식으로 주입하기 위해 `@ConstructorBinding`을 사용하는 경우, 해당 클래스는 `@Component`와 같이 빈으로 관리되면 안 된다.

![image](https://github.com/Igloo-Club/Igloo-Club-BE/assets/50361496/5c9b9b85-1c7b-442a-9112-c85c257b5cf1)

+ 따라서 빈으로 관리되지 않는 내부 클래스를 선언하여 해당 클래스에 주입하도록 하였다.

## 📚 Reference

- [@Value와 @ConfigurationProperties의 사용법 및 차이](https://mangkyu.tistory.com/207)
- [생성자 바인딩(Constructor Binding)](https://mangkyu.tistory.com/189)
- [@ConfigurationPropertiesScan을 이용한 설정 프로퍼티 클래스(@Configuration Properties)의 빈 등록](https://mangkyu.tistory.com/191)
- [Annotation Interface ConstructorBinding](https://docs.spring.io/spring-boot/docs/3.0.13-SNAPSHOT/api/org/springframework/boot/context/properties/ConstructorBinding.html)
- [Annotated with @ConstructorBinding but defined as Spring component 해결](https://velog.io/@bahar-j/Annotated-with-ConstructorBinding-but-defined-as-Spring-component-%ED%95%B4%EA%B2%B0)
