### PR TITLE
[fix] 눈길 상세 정보 반환값에 expiredAt 추가

### DIFF
--- a/src/main/java/com/iglooclub/nungil/dto/NungilResponse.java
+++ b/src/main/java/com/iglooclub/nungil/dto/NungilResponse.java
@@ -1,15 +1,10 @@
 package com.iglooclub.nungil.dto;
 
-import com.iglooclub.nungil.domain.Contact;
-import com.iglooclub.nungil.domain.FaceDepictionAllocation;
-import com.iglooclub.nungil.domain.enums.Hobby;
-import com.iglooclub.nungil.domain.PersonalityDepictionAllocation;
 import com.iglooclub.nungil.domain.enums.*;
 import lombok.Builder;
 import lombok.Data;
 
-import java.util.List;
-import java.util.stream.Collectors;
+import java.time.LocalDateTime;
 
 @Data
 @Builder
@@ -50,4 +45,5 @@ public class NungilResponse {
 
     private String hobbyAllocationList;
 
+    private LocalDateTime expiredAt;
 }

--- a/src/main/java/com/iglooclub/nungil/service/MemberService.java
+++ b/src/main/java/com/iglooclub/nungil/service/MemberService.java
@@ -158,10 +158,10 @@ public class MemberService {
     }
 
     /**
-     * 매일 오후 3시에 drawCount = 0으로 초기화
+     * 매일 자정에 drawCount = 0으로 초기화
      *
      */
-    @Scheduled(cron = "0 0 15 * * *") // 매일 오후 3시에 실행
+    @Scheduled(cron = "0 0 0 * * *") // 매일 자정에 실행
     @Transactional
     public void initMemberDrawCount() {
         memberRepository.initDrawCount();

--- a/src/main/java/com/iglooclub/nungil/service/NungilService.java
+++ b/src/main/java/com/iglooclub/nungil/service/NungilService.java
@@ -182,7 +182,9 @@ public class NungilService {
         Nungil nungil = nungilRepository.findById(nungilId)
                 .orElseThrow(() -> new GeneralException(NungilErrorResult.NUNGIL_NOT_FOUND));
         Member member = nungil.getReceiver();
-        return convertToNungilResponse(member);
+        NungilResponse nungilResponse = convertToNungilResponse(member);
+        nungilResponse.setExpiredAt(nungil.getExpiredAt());
+        return nungilResponse;
     }
 
     /**

--- a/src/main/java/com/iglooclub/nungil/service/NungilService.java
+++ b/src/main/java/com/iglooclub/nungil/service/NungilService.java
@@ -79,7 +79,7 @@ public class NungilService {
         member.plusDrawCount();
 
         // 6. 추천 받은 회원 정보를 반환한다.
-        return convertToNungilResponse(recommendedMember, newNungil);
+        return convertToNungilResponse(newNungil);
     }
 
     @Nullable
@@ -182,7 +182,7 @@ public class NungilService {
         Nungil nungil = nungilRepository.findById(nungilId)
                 .orElseThrow(() -> new GeneralException(NungilErrorResult.NUNGIL_NOT_FOUND));
         Member member = nungil.getReceiver();
-        NungilResponse nungilResponse = convertToNungilResponse(member, nungil);
+        NungilResponse nungilResponse = convertToNungilResponse(nungil);
         return nungilResponse;
     }
 
@@ -354,26 +354,26 @@ public class NungilService {
     }
 
     //Member 엔티티의 데이터를 NungilResponseDTO로 변환하는 메서드
-    private NungilResponse convertToNungilResponse(Member member, Nungil nungil) {
+    private NungilResponse convertToNungilResponse(Nungil nungil) {
         return NungilResponse.builder()
-                .id(member.getId())
-                .location(member.getLocation().getTitle())
-                .sex(member.getSex())
-                .age(LocalDateTime.now().minusYears(member.getBirthdate().getYear()).getYear())
-                .companyName(member.getCompany().getCompanyName())
-                .nickname(member.getNickname())
-                .animalFace(member.getAnimalFace().getTitle())
-                .alcohol(member.getAlcohol().getTitle())
-                .smoke(member.getSmoke().getTitle())
-                .religion(member.getReligion().getTitle())
-                .mbti(member.getMbti())
-                .job(member.getJob())
-                .height(member.getHeight())
-                .marriageState(member.getMarriageState().getTitle())
-                .faceDepictionAllocationList(member.getFaceDepictionAllocationsAsString())
-                .personalityDepictionAllocationList(member.getPersonalityDepictionAllocationAsString())
-                .description(member.getDescription())
-                .hobbyAllocationList(member.getHobbyAllocationAsString())
+                .id(nungil.getReceiver().getId())
+                .location(nungil.getReceiver().getLocation().getTitle())
+                .sex(nungil.getReceiver().getSex())
+                .age(LocalDateTime.now().minusYears(nungil.getReceiver().getBirthdate().getYear()).getYear())
+                .companyName(nungil.getReceiver().getCompany().getCompanyName())
+                .nickname(nungil.getReceiver().getNickname())
+                .animalFace(nungil.getReceiver().getAnimalFace().getTitle())
+                .alcohol(nungil.getReceiver().getAlcohol().getTitle())
+                .smoke(nungil.getReceiver().getSmoke().getTitle())
+                .religion(nungil.getReceiver().getReligion().getTitle())
+                .mbti(nungil.getReceiver().getMbti())
+                .job(nungil.getReceiver().getJob())
+                .height(nungil.getReceiver().getHeight())
+                .marriageState(nungil.getReceiver().getMarriageState().getTitle())
+                .faceDepictionAllocationList(nungil.getReceiver().getFaceDepictionAllocationsAsString())
+                .personalityDepictionAllocationList(nungil.getReceiver().getPersonalityDepictionAllocationAsString())
+                .description(nungil.getReceiver().getDescription())
+                .hobbyAllocationList(nungil.getReceiver().getHobbyAllocationAsString())
                 .expiredAt(nungil.getExpiredAt())
                 .build();
     }

--- a/src/main/java/com/iglooclub/nungil/service/NungilService.java
+++ b/src/main/java/com/iglooclub/nungil/service/NungilService.java
@@ -79,7 +79,7 @@ public class NungilService {
         member.plusDrawCount();
 
         // 6. 추천 받은 회원 정보를 반환한다.
-        return convertToNungilResponse(recommendedMember);
+        return convertToNungilResponse(recommendedMember, newNungil);
     }
 
     @Nullable
@@ -182,8 +182,7 @@ public class NungilService {
         Nungil nungil = nungilRepository.findById(nungilId)
                 .orElseThrow(() -> new GeneralException(NungilErrorResult.NUNGIL_NOT_FOUND));
         Member member = nungil.getReceiver();
-        NungilResponse nungilResponse = convertToNungilResponse(member);
-        nungilResponse.setExpiredAt(nungil.getExpiredAt());
+        NungilResponse nungilResponse = convertToNungilResponse(member, nungil);
         return nungilResponse;
     }
 
@@ -355,7 +354,7 @@ public class NungilService {
     }
 
     //Member 엔티티의 데이터를 NungilResponseDTO로 변환하는 메서드
-    private NungilResponse convertToNungilResponse(Member member) {
+    private NungilResponse convertToNungilResponse(Member member, Nungil nungil) {
         return NungilResponse.builder()
                 .id(member.getId())
                 .location(member.getLocation().getTitle())
@@ -375,6 +374,7 @@ public class NungilService {
                 .personalityDepictionAllocationList(member.getPersonalityDepictionAllocationAsString())
                 .description(member.getDescription())
                 .hobbyAllocationList(member.getHobbyAllocationAsString())
+                .expiredAt(nungil.getExpiredAt())
                 .build();
     }
 

--- a/src/main/java/com/iglooclub/nungil/service/NungilService.java
+++ b/src/main/java/com/iglooclub/nungil/service/NungilService.java
@@ -337,11 +337,11 @@ public class NungilService {
     }
 
     /**
-     * 매일 오전 11시에 추천된 눈길을 삭제하고,
+     * 매일 자정에 추천된 눈길을 삭제하고,
      * 전날에 추천되었던 회원이 다시 추천될 수 있도록 합니다.
      *
      */
-    @Scheduled(cron = "0 0 11 * * *") // 매일 오전 11시에 실행
+    @Scheduled(cron = "0 0 0 * * *") // 매일 자정에 실행
     @Transactional
     public void deleteRecommendedNungils() {
         nungilRepository.deleteAllByStatus(NungilStatus.RECOMMENDED);


### PR DESCRIPTION
## 🔥 Related Issues

- close #73 

## 💜 작업 내용

- [x] nungilResponse, getNungilDetailResponse 에 expiredAt 추가 

## ✅ PR Point

- ` convertToNungilResponse` 메서드에서 nungil을 매개변수로 추가로 받아 expiredAt을 사용 가능하게끔 변경
```
    private NungilResponse convertToNungilResponse(Member member, Nungil nungil) {
        return NungilResponse.builder()
                .id(member.getId())
                ,,,,
                .expiredAt(nungil.getExpiredAt())
                .build();
    }
```
- ` convertToNungilResponse`을 사용하는 경우 nungil을 매개변수에 추가
NungilService/recommendMember.java
```
        ,,,,
        // 6. 추천 받은 회원 정보를 반환한다.
        return convertToNungilResponse(recommendedMember, newNungil);
    }
```
NungilService/getNungilDetail.java
```
    public NungilResponse getNungilDetail(Long nungilId){
        Nungil nungil = nungilRepository.findById(nungilId)
                .orElseThrow(() -> new GeneralException(NungilErrorResult.NUNGIL_NOT_FOUND));
        Member member = nungil.getReceiver();
        NungilResponse nungilResponse = convertToNungilResponse(member, nungil);
        return nungilResponse;
    }
```



