### PR TITLE
hotfix: 마케팅 수신 동의 약관

### DIFF
--- a/src/main/java/com/iglooclub/nungil/controller/MemberController.java
+++ b/src/main/java/com/iglooclub/nungil/controller/MemberController.java
@@ -26,6 +26,13 @@ public class MemberController {
         return ResponseEntity.ok(null);
     }
 
+    @GetMapping("/api/member/consent")
+    public ResponseEntity<?> getConsentPolicy(Principal principal) {
+        Member member = getMember(principal);
+        ConsentPolicyResponse consentPolicy = memberService.getConsentPolicy(member);
+        return ResponseEntity.ok(consentPolicy);
+    }
+
     @PostMapping("/api/member")
     public ResponseEntity<?> createProfile(@RequestBody @Valid ProfileUpdateRequest request, Principal principal) {
         Member member = getMember(principal);

--- a/src/main/java/com/iglooclub/nungil/dto/ConsentPolicyResponse.java
+++ b/src/main/java/com/iglooclub/nungil/dto/ConsentPolicyResponse.java
@@ -1,0 +1,21 @@
+package com.iglooclub.nungil.dto;
+
+import com.iglooclub.nungil.domain.ConsentPolicy;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ConsentPolicyResponse {
+
+    private Boolean agreeMarketing;
+
+    public static ConsentPolicyResponse create(ConsentPolicy consentPolicy) {
+        ConsentPolicyResponse response = new ConsentPolicyResponse();
+
+        response.agreeMarketing = consentPolicy != null && consentPolicy.getAgreeMarketing();
+
+        return response;
+    }
+}

--- a/src/main/java/com/iglooclub/nungil/dto/MemberDetailResponse.java
+++ b/src/main/java/com/iglooclub/nungil/dto/MemberDetailResponse.java
@@ -1,18 +1,18 @@
 package com.iglooclub.nungil.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.iglooclub.nungil.domain.ConsentPolicy;
 import com.iglooclub.nungil.domain.Member;
 import com.iglooclub.nungil.domain.enums.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 import java.util.List;
 
 @Getter
-@AllArgsConstructor
-@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberDetailResponse {
     private String nickname;
 
@@ -55,6 +55,8 @@ public class MemberDetailResponse {
 
     private Boolean disableCompany;
 
+    private Boolean agreeMarketing;
+
     // == 생성 메서드 == //
     public static MemberDetailResponse create(Member member) {
         List<FaceDepiction> faceDepictionList = member.getFaceDepictionList();
@@ -63,27 +65,32 @@ public class MemberDetailResponse {
         List<AvailableTime> availableTimeList = member.getAvailableTimeList();
         List<Hobby> hobbyList = member.getHobbyList();
 
-        return MemberDetailResponse.builder()
-                .nickname(member.getNickname())
-                .sex(member.getSex())
-                .birthdate(member.getBirthdate())
-                .contactKakao(member.getContact().getKakao())
-                .contactInstagram(member.getContact().getInstagram())
-                .animalFace(member.getAnimalFace())
-                .job(member.getJob())
-                .height(member.getHeight())
-                .mbti(member.getMbti())
-                .marriageState(member.getMarriageState())
-                .religion(member.getReligion())
-                .alcohol(member.getAlcohol())
-                .smoke(member.getSmoke())
-                .faceDepictionList(faceDepictionList)
-                .personalityDepictionList(personalityDepictionList)
-                .description(member.getDescription())
-                .markerList(markerList)
-                .availableTimeList(availableTimeList)
-                .hobbyList(hobbyList)
-                .disableCompany(member.getDisableCompany())
-                .build();
+        MemberDetailResponse response = new MemberDetailResponse();
+
+        response.nickname = member.getNickname();
+        response.sex = member.getSex();
+        response.birthdate = member.getBirthdate();
+        response.contactKakao = member.getContact().getKakao();
+        response.contactInstagram = member.getContact().getInstagram();
+        response.animalFace = member.getAnimalFace();
+        response.job = member.getJob();
+        response.height = member.getHeight();
+        response.mbti = member.getMbti();
+        response.marriageState = member.getMarriageState();
+        response.religion = member.getReligion();
+        response.alcohol = member.getAlcohol();
+        response.smoke = member.getSmoke();
+        response.faceDepictionList = faceDepictionList;
+        response.personalityDepictionList = personalityDepictionList;
+        response.description = member.getDescription();
+        response.markerList = markerList;
+        response.availableTimeList = availableTimeList;
+        response.hobbyList = hobbyList;
+        response.disableCompany = member.getDisableCompany();
+
+        ConsentPolicy consentPolicy = member.getConsentPolicy();
+        response.agreeMarketing = consentPolicy != null && consentPolicy.getAgreeMarketing();
+
+        return response;
     }
 }

--- a/src/main/java/com/iglooclub/nungil/service/MemberService.java
+++ b/src/main/java/com/iglooclub/nungil/service/MemberService.java
@@ -199,4 +199,8 @@ public class MemberService {
 
         member.updateConsentPolicy(consentPolicy);
     }
+
+    public ConsentPolicyResponse getConsentPolicy(Member member) {
+        return ConsentPolicyResponse.create(member.getConsentPolicy());
+    }
 }


### PR DESCRIPTION
## 💜 작업 내용

- [x] 마케팅 수신 동의 여부(`agreeMarketing`) 조회 API 추가
- [x] 사용자 본인 정보 조회 API의 응답 값에 `agreeMarketing` 추가

## ✅ PR Point

기존 사용자들의 데이터 중 `agreeMarketing` 값이 `null`인 사용자들이 대다수였기 때문에
`agreeMarketing`이 `null`인 경우에 마케팅 수신 동의 여부 값이 `null`이 아닌 `false`가 되도록 하였습니다.

```java
@Getter
@NoArgsConstructor(access = AccessLevel.PROTECTED)
public class ConsentPolicyResponse {

    private Boolean agreeMarketing;

    public static ConsentPolicyResponse create(ConsentPolicy consentPolicy) {
        ConsentPolicyResponse response = new ConsentPolicyResponse();

        response.agreeMarketing = consentPolicy != null && consentPolicy.getAgreeMarketing();

        return response;
    }
}
```
